### PR TITLE
「寄付する」リンク先の修正

### DIFF
--- a/app/routes/_layout.support.tsx
+++ b/app/routes/_layout.support.tsx
@@ -39,7 +39,7 @@ export const meta: MetaFunction = () => {
   const ogType = "article";
   const ogTitle = title;
   const ogDescription = description;
-  const ogUrl = `https://healthy-person-emulator.org/beSponsor`;
+  const ogUrl = `https://healthy-person-emulator.org/support`;
   const twitterCard = "summary"
   const twitterSite = "@helthypersonemu"
   const twitterTitle = title

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -144,7 +144,7 @@ export default function Component() {
             プライバシー・ポリシー/免責事項
           </NavLink>
           <NavLink
-            to="/beSponsor"
+            to="/support"
             className="text-gray-700 hover:text-blue-500"
           >
             寄付する


### PR DESCRIPTION
Fix: #5 

ついでに `ogUrl` も `/beSponsor` のままだったので修正しました。

<img width="511" alt="image" src="https://github.com/sora32127/healthy-person-emulator-dotorg/assets/42153744/f5cff339-2499-48e3-a179-8c98ef3ad813">
