### PR TITLE
og:image propertyを追加

### DIFF
--- a/app/routes/_layout.archives.$postId.tsx
+++ b/app/routes/_layout.archives.$postId.tsx
@@ -612,6 +612,7 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
     { property: "og:site_name", content: ogSiteName },
     { property: "og:type", content: ogType },
     { property: "og:url", content: ogUrl },
+    { property: "og:image", content: twitterImage},
     { name: "twitter:card", content: twitterCard },
     { name: "twitter:site", content: twitterSite },
     { name: "twitter:title", content: twitterTitle },


### PR DESCRIPTION
TwiiterのみOGP画像に対応していたが、ほかの媒体でもOGPに対応できるよう修正した