### PR TITLE
見た目の改修を行った

### DIFF
--- a/app/components/CommentShowCard.tsx
+++ b/app/components/CommentShowCard.tsx
@@ -45,7 +45,7 @@ export default function CommentShowCard({
               <div className="w-6 h-6">
                   <ArticleIcon />
               </div>
-              <NavLink to={`/archives/${postId}`} className="text-lg font-bold text-info underline underline-offset-4 post-title">{dimPosts.postTitle}</NavLink>
+              <NavLink to={`/archives/${postId}`} className="text-xl font-bold text-info underline underline-offset-4 post-title">{dimPosts.postTitle}</NavLink>
           </div>
       </div>
   );

--- a/app/components/CommentShowCard.tsx
+++ b/app/components/CommentShowCard.tsx
@@ -45,7 +45,7 @@ export default function CommentShowCard({
               <div className="w-6 h-6">
                   <ArticleIcon />
               </div>
-              <NavLink to={`/archives/${postId}`} className="text-xl font-bold text-info underline underline-offset-4 post-title">{dimPosts.postTitle}</NavLink>
+              <NavLink to={`/archives/${postId}`} className="text-lg font-bold text-info underline underline-offset-4 post-title">{dimPosts.postTitle}</NavLink>
           </div>
       </div>
   );

--- a/app/components/PostCard.tsx
+++ b/app/components/PostCard.tsx
@@ -55,7 +55,7 @@ export default function PostCard({
             </div>
             <div className="grid grid-cols-[auto_1fr] gap-2 mb-2 items-center">
                 <ArticleIcon/>
-                <NavLink to={`/archives/${postId}`} className="text-lg font-bold text-info underline underline-offset-4 post-title">{postTitle}</NavLink>
+                <NavLink to={`/archives/${postId}`} className="text-xl font-bold text-info underline underline-offset-4 post-title">{postTitle}</NavLink>
             </div>
             {highLightedText && (
                 <p className="neutral-content">{parse(highLightedText)}</p>

--- a/app/components/PostCard.tsx
+++ b/app/components/PostCard.tsx
@@ -52,7 +52,7 @@ export default function PostCard({
             </div>
             <div className="grid grid-cols-[auto_1fr] gap-2 mb-2 items-center">
                 <ArticleIcon/>
-                <NavLink to={`/archives/${postId}`} className="text-xl font-bold text-info underline underline-offset-4 post-title">{postTitle}</NavLink>
+                <NavLink to={`/archives/${postId}`} className="text-lg font-bold text-info underline underline-offset-4 post-title">{postTitle}</NavLink>
             </div>
             {highLightedText && (
                 <p className="neutral-content">{parse(highLightedText)}</p>
@@ -61,7 +61,7 @@ export default function PostCard({
                 <TagIcon/>
                 <div className="flex flex-wrap items-center">
                     {tagNames && tagNames.map((tag, index) => (
-                        <span key={index} className="inline-block text-sm font-semibold mr-1 mb-1">
+                        <span key={index} className="inline-block mr-1 mb-1">
                             <TagCard tagName={tag} />
                         </span>
                     ))}

--- a/app/components/PostCard.tsx
+++ b/app/components/PostCard.tsx
@@ -45,6 +45,9 @@ export default function PostCard({
         return 0;
     });
 
+    const displayedTags = tagNames.slice(0, 5);
+    const hiddenTagsCount = tagNames.length - displayedTags.length;
+
     return (
         <div className="bg-base-100 border-2 rounded-lg p-4 mb-4">
             <div className="flex justify-between items-center mb-2">
@@ -60,11 +63,16 @@ export default function PostCard({
             <div className="grid grid-cols-[auto_1fr] gap-2 mt-2 items-center">
                 <TagIcon/>
                 <div className="flex flex-wrap items-center">
-                    {tagNames && tagNames.map((tag, index) => (
+                    {displayedTags.map((tag, index) => (
                         <span key={index} className="inline-block mr-1 mb-1">
                             <TagCard tagName={tag} />
                         </span>
                     ))}
+                    {hiddenTagsCount > 0 && (
+                        <span className="inline-block text-base-content">
+                            (+{hiddenTagsCount}タグ)
+                        </span>
+                    )}
                 </div>
             </div>
             <div className="flex items-center mt-2">

--- a/app/components/TagCard.tsx
+++ b/app/components/TagCard.tsx
@@ -9,7 +9,7 @@ export default function TagCard({
 }: TagCardProps) {
     return (
         <div className="rounded-md p-0.5 mb-0.5">
-            <NavLink to={`/tags/${tagName}`} className="text-lg font-bold text-info underline underline-offset-4 post-tag">{tagName}</NavLink>
+            <NavLink to={`/tags/${tagName}`} className="text-xs text-info underline underline-offset-4 post-tag">{tagName}</NavLink>
         </div>
     );
 }

--- a/app/routes/_layout.archives.$postId.tsx
+++ b/app/routes/_layout.archives.$postId.tsx
@@ -74,7 +74,7 @@ export async function loader({ request }:LoaderFunctionArgs){
     const { data, error } = await supabase.rpc("search_similar_content", {
       query_post_id: Number(postId),
       match_threshold: 0,
-      match_count: 15,
+      match_count: 16,
     });
 
     let similarPosts = [];

--- a/app/routes/_layout.archives.$postId.tsx
+++ b/app/routes/_layout.archives.$postId.tsx
@@ -74,7 +74,7 @@ export async function loader({ request }:LoaderFunctionArgs){
     const { data, error } = await supabase.rpc("search_similar_content", {
       query_post_id: Number(postId),
       match_threshold: 0,
-      match_count: 10,
+      match_count: 15,
     });
 
     let similarPosts = [];


### PR DESCRIPTION
# やったこと
- 記事ページ内部で表示する関連記事の数を9個から15個に変更した
  - 関連記事から遷移するユーザーが多かったため
- PostCardの見た目を調整した
  - フォントサイズを変更した
  - 表示されるタグ数を最大5個までにして、ほかは省略されるようにした