### PR TITLE
Configure robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,6 @@
 User-agent: *
 Disallow: /logout
+Disallow: /wp-json/
+Disallow: /archives/tag/
+Disallow: /archives/*/feed
+Disallow: /wp-login.php


### PR DESCRIPTION
wordpress時代のクローリングが残ってnew relicのログのノイズになるため、robots.txtで明示的にクローリングを禁止した