### PR TITLE
【機能追加】無期限いいね順を追加

### DIFF
--- a/app/routes/_layout._index.tsx
+++ b/app/routes/_layout._index.tsx
@@ -192,7 +192,7 @@ export default function Feed() {
                     />
                 ))}
                 <NavLink
-                    to="/feed?p=2"
+                    to="/feed?p=2&type=timeDesc"
                     className="rounded-md block w-full px-4 py-2 text-center text-white bg-primary"
                 >
                 最新の投稿を見る
@@ -212,7 +212,7 @@ export default function Feed() {
                     />
                 ))}
                 <NavLink
-                    to="/feed?p=2&likeFrom=24&likeTo=0"
+                    to="/feed?p=2&likeFrom=24&likeTo=0&type=like"
                     className="rounded-md block w-full px-4 py-2 text-center text-white bg-primary"
                 >
                 最近いいねされた投稿を見る

--- a/app/routes/_layout.feed.tsx
+++ b/app/routes/_layout.feed.tsx
@@ -15,14 +15,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   if (likeFromHour) {
     const likeFromHourInt = parseInt(likeFromHour);
     const likeToHourInt = parseInt(likeToHour || "0");
-    let now;
-    if (process.env.NODE_ENV === "development") {
-      now = new Date("2024-03-11")
-    }
-    else{
-      now = new Date();
-    }
-
+    const now = new Date();
     const gteDate = new Date(now.getTime() - likeFromHourInt * 60 * 60 * 1000);
     const lteDate = new Date(now.getTime() - likeToHourInt * 60 * 60 * 1000);
 

--- a/app/routes/_layout.feed.tsx
+++ b/app/routes/_layout.feed.tsx
@@ -157,15 +157,13 @@ export default function Feed() {
       <div className="feed-type-select">
         <Form method="post" className="mb-4">
           <div className="flex items-center">
-            <button
+          <button
               type="submit"
               name="action"
               value="sortByNew"
-              className={`px-4 py-2 mr-2 ${
-                !likeFromHour
-                  ? "bg-base-200 text-base-content border-4 border-info  focus:outline-info"
-                  : "bg-base-200 text-base-content focus:outline-info"
-              } rounded`}
+              className={`btn mx-2 ${
+                !likeFromHour ? "border-info border-4" : ""
+              }`}
             >
               新着順
             </button>
@@ -173,13 +171,19 @@ export default function Feed() {
               type="submit"
               name="action"
               value="sortByLikes"
-              className={`px-4 py-2 ${
-                likeFromHour
-                  ? "bg-base-200 text-base-content border-4 border-info  focus:outline-info"
-                  : "bg-base-200 text-base-content focus:outline-info"
-              } rounded`}
+              className={`btn mx-2 ${
+                likeFromHour ? " border-info border-4" : ""
+              }`}
             >
               いいね順
+            </button>
+            <button
+              type="submit"
+              name="action"
+              value="unbounedLikes"
+              className="btn mx-2"
+            >
+              無期限いいね順
             </button>
           </div>
         </Form>

--- a/app/routes/_layout.feed.tsx
+++ b/app/routes/_layout.feed.tsx
@@ -335,10 +335,9 @@ export const meta: MetaFunction = ({ location }) => {
   
   if (type === "unboundedLikes"){
     title = `無期限いいね順 - ページ${pageNumber}`;
-  }
-  else if (!likeFrom){
+  } else if (type === "timeDesc"){
     title = pageNumber ? `フィード - ページ${pageNumber}` : "フィード"
-  } else {
+  } else if (type === "like") {
     title = `いいね順 - ${likeFrom}時間前～${likeTo}時間前`
   }
 

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -15,6 +15,7 @@ import SignupIcon from "~/components/icons/SignupIcon";
 import LoginIcon from "~/components/icons/LoginIcon";
 import MenuIcon from "~/components/icons/MenuIcon";
 import TopIcon from "~/components/icons/TopIcon";
+import ThumbsUpIcon from "~/components/icons/ThumbsUpIcon";
 
 export async function loader({ request }: LoaderFunctionArgs){
   const session = await getSession(request.headers.get("Cookie"));
@@ -40,6 +41,7 @@ export default function Component() {
   const menuItems = [
     { to: "/support", text: "サポートする", icon: DonationIcon },
     { to: "/readme", text: "サイト説明", icon: GuidelineIcon },
+    { to: "/feed?p=1&type=unboundedLikes", text: "無期限いいね順", icon: ThumbsUpIcon},
     ...(isLoggedIn
       ? [
           { to: "/logout", text: "ログアウト", icon: LogoutIcon },

--- a/tests/readOnlyTest.spec.ts
+++ b/tests/readOnlyTest.spec.ts
@@ -64,12 +64,16 @@ test.describe("フィードページ", () => {
     await verifyElementMinCount(page, ".feed-posts > div", 4);
   });
 
-  test("新着順といいね順を切り替えられる", async ({ page }) => {
+  test("新着順・いいね順・無期限いいね順を切り替えられる", async ({ page }) => {
     await navigateToLatestFeed(page);
-    await page.getByText("いいね順").click();
+    await page.getByText("いいね順").nth(0).click();
     await expect(page).toHaveTitle(/いいね順 - 24時間前～0時間前/);
     await page.getByText("新着順").click();
     await expect(page).toHaveTitle(/フィード - ページ1/);
+    await page.getByText("無期限いいね順").click();
+    await expect(page).toHaveTitle(/無期限いいね順 - ページ1/);
+    await verifyElementCount(page, ".feed-posts > div", 10);
+
   });
 });
 


### PR DESCRIPTION
# やったこと
- 「無期限いいね順」を追加
  - 過去に投稿された記事をいいね数順に閲覧できる機能
- フィードページをリファクタリング
- トップレイアウトに無期限いいね順へのリンクを追加