### PR TITLE
【機能追加】検索画面でいいね数・新着順の並び替え機能を追加

### DIFF
--- a/app/components/SubmitFormComponents/TagSelectionBox.tsx
+++ b/app/components/SubmitFormComponents/TagSelectionBox.tsx
@@ -51,15 +51,15 @@ const TagSelectionBox = ({
                 value={searchText}
                 onChange={e => setSearchText(e.target.value)}
                 placeholder="タグを検索..."
-                className="w-full px-3 py-2 placeholder-slate-500 border rounded-lg focus:outline-none mb-4"
+                className="input input-bordered w-full px-3 py-2 placeholder-slate-500  mb-4"
             />
             <div className="flex space-x-2 mb-4">
                 <button
                     type="button"
-                    className={`px-4 py-2 rounded-lg focus:outline-none ${
+                    className={`px-4 py-2 btn ${
                         sortBy === 'count'
-                            ? 'text-white bg-blue-600'
-                            : 'text-gray-700 bg-gray-200 hover:bg-gray-300'
+                            ? ' btn-primary'
+                            : 'btn-neutral'
                     }`}
                     onClick={() => setSortBy('count')}
                 >
@@ -67,10 +67,10 @@ const TagSelectionBox = ({
                 </button>
                 <button
                     type="button"
-                    className={`px-4 py-2 rounded-lg focus:outline-none ${
+                    className={`px-4 py-2 btn ${
                         sortBy === 'name'
-                            ? 'text-white bg-blue-600'
-                            : 'text-gray-700 bg-gray-200 hover:bg-gray-300'
+                            ? ' btn-primary'
+                            : 'btn-neutral'
                     }`}
                     onClick={() => setSortBy('name')}
                 >
@@ -81,10 +81,10 @@ const TagSelectionBox = ({
             {filteredTags.map(tag => (
             <button
                 key={`${tag.tagName}-${tag.count}`}
-                className={`px-4 py-2 rounded-lg cursor-pointer focus:outline-none ${
+                className={`px-4 py-2 rounded-lg cursor-pointer btn ${
                 parentComponentStateValues.includes(tag.tagName)
-                    ? 'text-white bg-blue-600'
-                    : 'text-gray-700 bg-gray-200 hover:bg-gray-300'
+                    ? 'btn-active'
+                    : 'text-gray-700 bg-gray-200'
                 }`}
                 onClick={() => handleTagClick(tag.tagName)}
                 type="button"
@@ -99,7 +99,7 @@ const TagSelectionBox = ({
                 {parentComponentStateValues.map(tag => (
                     <button
                         key={tag}
-                        className="inline-flex items-center px-2 py-1 mr-2 mb-2 text-sm font-medium text-gray-700 bg-gray-200 rounded-full cursor-pointer focus:outline-none"
+                        className="inline-flex items-center px-2 py-1 mr-2 mb-2 text-sm font-medium btn-active rounded-full cursor-pointer"
                         onClick={() => handleRemoveSelectedTag(tag)}
                         type="button"
                     >

--- a/app/routes/_layout.search.tsx
+++ b/app/routes/_layout.search.tsx
@@ -213,7 +213,6 @@ export const loader: LoaderFunction = async ({ request }) => {
         .filter((tag) => tag.postId === post.postId)
         .map((tag) => tag.dimTag.tagName),
     }));
-
     return json({
       data: searchResultsWithTags,
       allTagsForSearch,
@@ -368,10 +367,6 @@ export default function SearchPage() {
     }
   };
 
-  const handleCurrentOrderBy = (e: string) => {
-    setCurrentOrderBy(e as OrderBy);
-  }
-
   return (
     <div className="container mx-auto px-4">
       <H1>検索</H1>
@@ -393,7 +388,7 @@ export default function SearchPage() {
             <option value="fullText">全文検索</option>
             <option value="title">タイトル検索</option>
           </select>
-        <select className="select select-bordered" onChange={(e) => handleCurrentOrderBy(e.target.value)} value={currentOrderBy}>
+        <select className="select select-bordered" onChange={(e) =>  setCurrentOrderBy(e.target.value as OrderBy)}>
           <option disabled selected className="text-slate-500"> 並び替え</option>
           <option value="timeDesc">投稿日時順</option>
           <option value="like">いいね数順</option>

--- a/app/routes/_layout.search.tsx
+++ b/app/routes/_layout.search.tsx
@@ -386,9 +386,10 @@ export default function SearchPage() {
             id="search-type"
             value={currentSearchType}
             onChange={(e) => setCurrentSearchType(e.target.value as SearchType)}
-            className="rounded px-4 py-2 mb-4 md:mb-0 md:mr-4 focus:outline-none focus:ring-2 focus:ring-blue-500 w-full md:w-auto border-2 border-secondary bg-base-200"
+            className="select select-bordered"
             aria-label="検索タイプ"
           >
+            <option disabled selected className="text-slate-500"> 検索タイプ</option>
             <option value="tag">タグ検索</option>
             <option value="fullText">全文検索</option>
             <option value="title">タイトル検索</option>
@@ -403,7 +404,7 @@ export default function SearchPage() {
               />
               <button
                 type="submit"
-                className="bg-primary text-white px-6 py-2 rounded mt-2 md:mt-0 md:ml-2 w-full md:w-auto"
+                className="btn btn-primary px-6 py-2 rounded mt-2 md:mt-0 md:ml-2 w-full md:w-auto"
                 name="action"
                 value="firstSearch"
               >
@@ -419,12 +420,12 @@ export default function SearchPage() {
                 name="q"
                 defaultValue={queryText}
                 onChange={(e) => setQueryText(e.target.value)}
-                className="rounded px-4 py-2 w-full focus:outline-none focus:ring-2 focus:ring-blue-500 mb-2 md:mb-0 md:w-5/6 placeholder-slate-500 border-2 border-secondary"
+                className="input input-bordered px-4 py-2 w-full  mb-2 md:mb-0 md:w-5/6 placeholder-slate-500 border-secondary"
                 placeholder="検索キーワードを入力"
               />
               <button
               type="submit"
-              className="bg-primary text-white px-6 py-2 rounded mt-2 md:mt-0 md:ml-2 w-full md:w-auto"
+              className="btn btn-primary px-6 py-2 rounded mt-2 md:mt-0 md:ml-2 w-full md:w-auto"
               name="action"
               value="firstSearch"
               >
@@ -440,12 +441,12 @@ export default function SearchPage() {
             name="title"
             defaultValue={titleText}
             onChange={(e) => setTitleText(e.target.value)}
-            className="placeholder-slate-500 rounded px-4 py-2 w-full focus:outline-none focus:ring-2 focus:ring-blue-500 mb-2 md:mb-0 md:w-5/6 border-2 border-secondary"
+            className="input input-bordered px-4 py-2 w-full  mb-2 md:mb-0 md:w-5/6 placeholder-slate-500 border-secondary"
             placeholder="タイトルを入力"
             />
             <button
               type="submit"
-              className="bg-primary text-white px-6 py-2 rounded mt-2 md:mt-0 md:ml-2 w-full md:w-auto"
+              className="btn btn-primary px-6 py-2 rounded mt-2 md:mt-0 md:ml-2 w-full md:w-auto"
               name="action"
               value="firstSearch"
             >

--- a/app/routes/_layout.search.tsx
+++ b/app/routes/_layout.search.tsx
@@ -175,9 +175,8 @@ export const loader: LoaderFunction = async ({ request }) => {
   } else if (searchType === "fullText") {
     const query = url.searchParams.get("text") || "";
     const { data } = (await supabase.rpc("search_post_contents", {
-      keyword: query,
+      keyword: query, orderby:orderBy,
     })) as { data: HighlightedPostContent[] };
-
     if (!data) {
       return json({
         data: [],
@@ -394,7 +393,7 @@ export default function SearchPage() {
             <option value="fullText">全文検索</option>
             <option value="title">タイトル検索</option>
           </select>
-        <select className="select select-bordered" onChange={(e) => handleCurrentOrderBy(e.target.value)}>
+        <select className="select select-bordered" onChange={(e) => handleCurrentOrderBy(e.target.value)} value={currentOrderBy}>
           <option disabled selected className="text-slate-500"> 並び替え</option>
           <option value="timeDesc">投稿日時順</option>
           <option value="like">いいね数順</option>

--- a/app/routes/_layout.search.tsx
+++ b/app/routes/_layout.search.tsx
@@ -394,6 +394,12 @@ export default function SearchPage() {
             <option value="fullText">全文検索</option>
             <option value="title">タイトル検索</option>
           </select>
+        <select className="select select-bordered" onChange={(e) => handleCurrentOrderBy(e.target.value)}>
+          <option disabled selected className="text-slate-500"> 並び替え</option>
+          <option value="timeDesc">投稿日時順</option>
+          <option value="like">いいね数順</option>
+        </select>
+        <input type="hidden" name="orderBy" value={currentOrderBy} />
           {currentSearchType === "tag" && (
             <div className="w-full md:flex-row">
               <br></br>
@@ -456,12 +462,6 @@ export default function SearchPage() {
           </div>
         )}
         </div>
-        <select className="select select-bordered" onChange={(e) => handleCurrentOrderBy(e.target.value)}>
-            <option disabled selected className="text-slate-500"> 並び替え</option>
-            <option value="timeDesc">投稿日時順</option>
-            <option value="like">いいね数順</option>
-          </select>
-          <input type="hidden" name="orderBy" value={currentOrderBy} />
     </Form>
     <p className="text-lg mb-4 font-bold">{searchResultTitle()}</p>
     {data && data.length > 0 ? (


### PR DESCRIPTION
# やったこと
- 検索画面で、いいね数順/新着順に記事を並び替えられるようにした
- 検索画面のUIをdaisy UIで統一した