### PR TITLE
【hotfix】エラーの吐き出しのスタイルを変更

### DIFF
--- a/app/routes/_layout.archives.$postId.tsx
+++ b/app/routes/_layout.archives.$postId.tsx
@@ -79,7 +79,7 @@ export async function loader({ request }:LoaderFunctionArgs){
 
     let similarPosts = [];
     if (error) {
-      throw new Response(`Internal Server Error : Failed to fetch similar posts, ${error.message}`, { status: 500 });
+      console.error(error.code, error.message);
     }else{
       similarPosts = data.slice(1,);
     }


### PR DESCRIPTION
`throw new Error`だとページの読み込みがとまるため、console.errorに変更した