### PR TITLE
【Update】コミュニティ選の表示を変更した

### DIFF
--- a/app/routes/_layout._index.tsx
+++ b/app/routes/_layout._index.tsx
@@ -98,7 +98,9 @@ export async function loader() {
                 },
             },
         },
-    }}});
+    }},
+    take: 100
+});
 
     const famedPostsRaw = await prisma.relPostTags.findMany({
         where: { tagId: { equals: 575 } }, // コミュニティ選のtag_id

--- a/app/routes/_layout._index.tsx
+++ b/app/routes/_layout._index.tsx
@@ -99,7 +99,8 @@ export async function loader() {
             },
         },
     }},
-    take: 100
+    take: 100,
+    orderBy : { dim_posts : { postDateGmt : "desc" }},
 });
 
     const famedPostsRaw = await prisma.relPostTags.findMany({


### PR DESCRIPTION
# やったこと
- コミュニティ選の最新の投稿が表示されないのを治した
  - findManyにおいて、何も指定していない場合は上限取得数が24となる（らしい）
  - コミュニティ選の投稿数が25以上になり、最新の投稿が反映されない状態になっていたため、上限を引き上げた。
 - コミュニティ選の並び順を変更した
   - 変更前：投稿日の昇順
   - 変更後：投稿日の降順