### PR TITLE
UIを調整

### DIFF
--- a/app/components/CommentCard.tsx
+++ b/app/components/CommentCard.tsx
@@ -93,30 +93,34 @@ export default function CommentCard({
       </div>
       <p className="mt-2 whitespace-pre-wrap">{commentContent}</p>
       <div className="flex items-center mt-4">
-        <button
-          className={`flex items-center mr-4 bg-inherit rounded-md px-2 py-2 border ${
-            isLiked ? "text-blue-500 fonr-bold" : ""
-          } comment-like-button`}
-          onClick={() => (onCommentVote(commentId, "like"), setIsCommentLikeButtonPushed(true))}
-          disabled={isCommentLikeButtonPushed || isLiked}
-        >
-          <ThumbsUpIcon />
-          <p className="ml-2">
-          {likesCount}
-          </p>
-        </button>
-        <button
-          className={`flex items-center bg-inherit rounded-md px-2 py-2 border ${
-            isDisliked ? "text-red-500 font-bold" : ""
-          } comment-dislike-button`}
-          onClick={() => (onCommentVote(commentId, "dislike"), setIsCommentDislikeButtonPushed(true))}
-          disabled={isCommentDislikeButtonPushed || isDisliked}
-        >
-          <ThumbsDownIcon />
-          <p className="ml-2">
-          {dislikesCount}
-          </p>
-        </button>
+        <div className="tooltip" data-tip="このコメントを高評価する">
+          <button
+            className={`flex items-center mr-4 rounded-md px-2 py-2 bg-base-300 hover:bg-base-200 ${
+              isLiked ? "text-blue-500 font-bold" : ""
+            } comment-like-button`}
+            onClick={() => (onCommentVote(commentId, "like"), setIsCommentLikeButtonPushed(true))}
+            disabled={isCommentLikeButtonPushed || isLiked}
+          >
+            <ThumbsUpIcon />
+            <p className="ml-2">
+            {likesCount}
+            </p>
+          </button>
+        </div>
+        <div className="tooltip" data-tip="このコメントを低評価する">
+          <button
+            className={`flex items-center mr-4 rounded-md px-2 py-2 bg-base-300 hover:bg-base-200 ${
+              isDisliked ? "text-red-500 font-bold" : ""
+            } comment-dislike-button`}
+            onClick={() => (onCommentVote(commentId, "dislike"), setIsCommentDislikeButtonPushed(true))}
+            disabled={isCommentDislikeButtonPushed || isDisliked}
+          >
+            <ThumbsDownIcon />
+            <p className="ml-2">
+            {dislikesCount}
+            </p>
+          </button>
+        </div>
       </div>
     <button
         className="mt-2 text-blue-500"

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -102,7 +102,7 @@ export default function Component() {
           </li>
         </ul>
       </nav>
-      <div className="flex-1 p-4 ml-0 md:mx-64">
+      <div className="flex-1 p-4 ml-0 md:ml-64 md:mr-16 lg:ml-64 lg:mr-32 xl:ml-96 xl:mr-96">
         <div className="mb-32 md:mb-0">
           <Outlet />
         </div>


### PR DESCRIPTION
# やったこと
- メインコンテンツの横幅マージンを2段階から4段階に変更
- コメントに対するいいね・よくないねボタンをマテリアルデザインっぽいスタイルに変更
- コメントに対するいいね・よくないねボタンに対してツールチップを追加

# 横幅の段階
https://i.gyazo.com/ff5b01c347bb55e15a32244574b2deb5.gif

```tsx
<div className="flex-1 p-4 ml-0 md:ml-64 md:mr-16 lg:ml-64 lg:mr-32 xl:ml-96 xl:mr-96">
```

1段階目：スマトーフォン表示（768px未満）
2段階目：[md:]タブレット表示（786px ~ 1023px)
3段階目：[lg:]PC表示狭め（1024px ~ 1279px）
4段階目：[xl:]PC表示広め（1280px以上）