### PR TITLE
`sitemap.xml`を自動生成する処理を追加する

### DIFF
--- a/app/routes/_layout.archives.$postId.tsx
+++ b/app/routes/_layout.archives.$postId.tsx
@@ -18,7 +18,7 @@ import ThumbsUpIcon from "~/components/icons/ThumbsUpIcon";
 import ThumbsDownIcon from "~/components/icons/ThumbsDownIcon";
 import ArrowForwardIcon from "~/components/icons/ArrowForwardIcon";
 import RelativeDate from "~/components/RelativeDate";
-
+import { SEOHandle } from "@nasa-gcn/remix-seo";
 
 export async function loader({ request }:LoaderFunctionArgs){
     const url = new URL(request.url);
@@ -632,4 +632,16 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
     { name: "twitter:creator", content: twitterCreator },
     { name: "twitter:image", content: twitterImage },
   ];
+};
+
+export const handle: SEOHandle = {
+  getSitemapEntries: async (request) => {
+    const pages = await prisma.dimPosts.findMany()
+    return pages.map((post) => {
+      return {
+        route: `archives/${post.postId}`,
+        priority: 0.7
+      }
+    })
+  },
 };

--- a/app/routes/_layout.archives.edit.$postId.tsx
+++ b/app/routes/_layout.archives.edit.$postId.tsx
@@ -13,6 +13,8 @@ import { createEmbedding } from "~/modules/embedding.server";
 import TagSelectionBox from "~/components/SubmitFormComponents/TagSelectionBox";
 import { getAuth } from "@clerk/remix/ssr.server";
 import { setVisitorCookieData } from "~/modules/visitor.server";
+import { SEOHandle } from "@nasa-gcn/remix-seo";
+
 
 async function requireUserId(args: LoaderFunctionArgs) {
   const { userId } = await getAuth(args);
@@ -423,3 +425,7 @@ export const meta : MetaFunction = () => {
     { title : "編集"}
   ]
 }
+
+export const handle: SEOHandle = {
+  getSitemapEntries: () => null,
+};

--- a/app/routes/sitemap[.]xml.ts
+++ b/app/routes/sitemap[.]xml.ts
@@ -1,0 +1,12 @@
+import { routes } from "@remix-run/dev/server-build";
+import type { LoaderFunctionArgs } from "@remix-run/node";
+import { generateSitemap } from "@nasa-gcn/remix-seo";
+
+export function loader({ request }: LoaderFunctionArgs) {
+  return generateSitemap(request, routes, {
+    siteUrl: "https://healthy-person-emulator.org",
+    headers: {
+        "Cache-Control": `public, max-age=${60 * 60}`,
+    }
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@clerk/themes": "^2.1.10",
         "@estruyf/github-actions-reporter": "^1.6.0",
         "@marsidev/react-turnstile": "^0.5.3",
+        "@nasa-gcn/remix-seo": "^2.0.1",
         "@prisma/client": "^5.12.0",
         "@remix-run/node": "^2.8.1",
         "@remix-run/react": "^2.8.1",
@@ -1563,6 +1564,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@nasa-gcn/remix-seo": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@nasa-gcn/remix-seo/-/remix-seo-2.0.1.tgz",
+      "integrity": "sha512-g9biDdYfsdFBnOU7lM+7vPGEXSEMRnWmfVLDQ98pT0PnTT/O3pFuA+s3DA0Mj9IwnAq9IcLs2Wee/aL6fvEA+A==",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "@remix-run/react": "^1.0.0 || ^2.0.0",
+        "@remix-run/server-runtime": "^1.0.0 || ^2.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -8808,8 +8821,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@clerk/themes": "^2.1.10",
     "@estruyf/github-actions-reporter": "^1.6.0",
     "@marsidev/react-turnstile": "^0.5.3",
+    "@nasa-gcn/remix-seo": "^2.0.1",
     "@prisma/client": "^5.12.0",
     "@remix-run/node": "^2.8.1",
     "@remix-run/react": "^2.8.1",


### PR DESCRIPTION
# 変更したこと
- remix-seoを利用して`sitemap.xml`を自動生成する処理を追加した
- `archives/$postId`についてはダイナミックにsitemapを生成する
- `archives/edit/$postId`についてはサイトマップの除外処理を加える

# Issue Link
#82 