### PR TITLE
Fix: Enfore prisma client is single instanse

### DIFF
--- a/app/modules/db.server.ts
+++ b/app/modules/db.server.ts
@@ -1,5 +1,15 @@
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient } from "@prisma/client"
 
-const prisma = new PrismaClient()
+let prisma
+
+if (process.env.NODE_ENV === "production") {
+  prisma = new PrismaClient()
+} else {
+  if (!global.prisma) {
+    global.prisma = new PrismaClient()
+  }
+
+  prisma = global.prisma
+}
 
 export { prisma }


### PR DESCRIPTION
- prisma用のクライアントが常にグローバルに生成されると、ホットリロードのたびにコネクションプールが使われてしまい、結果としてコネクションプールがすぐ切れてしまう
- この問題を解消するため、prismaインスタンスがグローバルに生成されている場合は再度生成しないようにした