### PR TITLE
投稿タイトルのバリデーションを追加 & 投稿時に内容をクリアするように変更

### DIFF
--- a/app/components/Modal.tsx
+++ b/app/components/Modal.tsx
@@ -1,0 +1,28 @@
+interface ModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    title: string;
+    children: React.ReactNode;
+    showCloseButton?: boolean;
+  }
+  
+export function Modal({ isOpen, onClose, title, children, showCloseButton = true }: ModalProps) {
+    if (!isOpen) return null;
+  
+    return (
+      <dialog className="modal modal-open">
+        <div className="modal-box">
+          <h3 className="font-bold text-lg">{title}</h3>
+          <div className="py-4">{children}</div>
+          {showCloseButton && (
+            <div className="modal-action">
+              <button className="btn" onClick={onClose}>閉じる</button>
+            </div>
+          )}
+        </div>
+        <form method="dialog" className="modal-backdrop">
+          <button onClick={onClose}>close</button>
+        </form>
+      </dialog>
+    );
+}

--- a/app/modules/db.server.ts
+++ b/app/modules/db.server.ts
@@ -1,6 +1,10 @@
 import { PrismaClient } from "@prisma/client"
 
-let prisma
+let prisma: PrismaClient
+
+declare global {
+  var prisma: PrismaClient | undefined
+}
 
 if (process.env.NODE_ENV === "production") {
   prisma = new PrismaClient()


### PR DESCRIPTION
# 変更したこと
- 投稿成功時にlocalstorageの中身をクリアするように変更した
- 投稿タイトルに「# (ハッシュタグ)」が含まれている場合、モーダルを表示して投稿をはじくようにした
- 投稿成功時にモーダルを表示してからリダイレクトするようにした

# 内部変更
- prismaクライアントの型定義を追加
