### PR TITLE
レイアウトの変更

### DIFF
--- a/app/components/Headings.tsx
+++ b/app/components/Headings.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 export const H1: React.FC<{ children: React.ReactNode }> = ({ children }) => {
     return <h1 className="text-3xl font-bold mt-16 mb-6 text-center">{children}</h1>;
 };

--- a/app/components/PostCard.tsx
+++ b/app/components/PostCard.tsx
@@ -76,7 +76,7 @@ export default function PostCard({
                 <NavLink to={`/archives/${postId}`} className="hover:underline hover:underline-offset-4">
                     <img src={`https://healthy-person-emulator-public-assets.s3.ap-northeast-1.amazonaws.com/${postId}.jpg`} alt={postTitle} className="w-full object-cover" loading="lazy"/>
                     <div className="mt-1 mb-2">
-                        <p className="text-xl">{postTitle}</p>
+                        <p className="text-xl font-bold">{postTitle}</p>
                     </div>
                 </NavLink>
                 <div>

--- a/app/components/PostCard.tsx
+++ b/app/components/PostCard.tsx
@@ -3,6 +3,9 @@ import TagCard from "./TagCard";
 import RelativeDate from "./RelativeDate";
 import { LiaThumbsUpSolid, LiaThumbsDownSolid } from "react-icons/lia";
 import { FaRegComments } from "react-icons/fa6";
+import CommentIcon from "./icons/CommentIcon";
+import ThumbsDownIcon from "./icons/ThumbsDownIcon";
+import ThumbsUpIcon from "./icons/ThumbsUpIcon";
 
 export interface PostCardProps {
     postId: number;
@@ -55,16 +58,16 @@ export default function PostCard({
                     </div>
                     <div className="flex items-center gap-x-4">
                         <div className="flex items-center">
-                            <LiaThumbsUpSolid/>
+                            <ThumbsUpIcon/>
                             <span className="text-sm text-base-content ml-1">{countLikes}</span>
                         </div>
                         <div className="flex items-center">
-                            <LiaThumbsDownSolid/>
+                            <ThumbsDownIcon/>
                             <span className="text-sm text-base-content ml-1">{countDislikes}</span>
                         </div>
                         {countComments !== undefined && (
                             <div className="flex items-center">
-                                <FaRegComments/>
+                                <CommentIcon/>
                                 <span className="text-sm text-base-content ml-1">{countComments}</span>
                             </div>
                         )}

--- a/app/components/ThemeSwitcher.tsx
+++ b/app/components/ThemeSwitcher.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { MdOutlineLightMode, MdOutlineDarkMode } from "react-icons/md";
 
 export default function ThemeSwitcher() {
   const [nowTheme, setNowTheme] = useState<string>();
@@ -14,34 +15,17 @@ export default function ThemeSwitcher() {
   }, []);
 
   const toggleTheme = () => {
-    const newTheme = nowTheme == "dark" ? "light" : "dark";
+    const newTheme = nowTheme === "dark" ? "light" : "dark";
     window.localStorage.setItem("theme", newTheme);
     setNowTheme(newTheme);
     document.querySelector("html")?.setAttribute("data-theme", newTheme);
   };
 
   return (
-    <div className="flex items-center gap-2">
-      <label htmlFor="theme-switcher">
-        <span className="sr-only">テーマ切り替え</span>
-        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <circle cx="12" cy="12" r="5" />
-          <path d="M12 1v2M12 21v2M4.2 4.2l1.4 1.4M18.4 18.4l1.4 1.4M1 12h2M21 12h2M4.2 19.8l1.4-1.4M18.4 5.6l1.4-1.4" />
-        </svg>
-      </label>
-      <input
-        type="checkbox"
-        id="theme-switcher"
-        checked={nowTheme == "dark"}
-        onChange={toggleTheme}
-        className="toggle theme-controller"
-      />
-      <label htmlFor="theme-switcher">
-        <span className="sr-only">ダークモード</span>
-        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
-        </svg>
-      </label>
+    <div className="tooltip tooltip-bottom" data-tip={nowTheme === "dark" ? "ライトモードに切り替え" : "ダークモードに切り替え"}>
+      <button onClick={toggleTheme} type="button" className="btn btn-ghost">
+        {nowTheme === "dark" ? <MdOutlineLightMode className="w-6 h-6" /> : <MdOutlineDarkMode className="w-6 h-6" />}
+      </button>
     </div>
   );
 }

--- a/app/components/ThemeSwitcher.tsx
+++ b/app/components/ThemeSwitcher.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from "react";
 import { MdOutlineLightMode, MdOutlineDarkMode } from "react-icons/md";
+import { AiOutlineLoading3Quarters } from "react-icons/ai";
 
 export default function ThemeSwitcher() {
   const [nowTheme, setNowTheme] = useState<string>();
+  const [isChanging, setIsChanging] = useState(false);
 
   useEffect(() => {
     if (window.localStorage.getItem("theme") === null) {
@@ -15,16 +17,18 @@ export default function ThemeSwitcher() {
   }, []);
 
   const toggleTheme = () => {
+    setIsChanging(true);
     const newTheme = nowTheme === "dark" ? "light" : "dark";
     window.localStorage.setItem("theme", newTheme);
     setNowTheme(newTheme);
     document.querySelector("html")?.setAttribute("data-theme", newTheme);
+    setTimeout(() => setIsChanging(false), 500);
   };
 
   return (
     <div className="tooltip tooltip-bottom" data-tip={nowTheme === "dark" ? "ライトモードに切り替え" : "ダークモードに切り替え"}>
-      <button onClick={toggleTheme} type="button" className="btn btn-ghost">
-        {nowTheme === "dark" ? <MdOutlineLightMode className="w-6 h-6" /> : <MdOutlineDarkMode className="w-6 h-6" />}
+      <button onClick={toggleTheme} type="button" className={`btn btn-circle ml-1 mt-1 ${isChanging ? 'animate-spin' : ''}`}>
+        {isChanging ? <AiOutlineLoading3Quarters className="w-6 h-6 animate-spin" /> : nowTheme === "dark" ? <MdOutlineLightMode className="w-6 h-6" /> : <MdOutlineDarkMode className="w-6 h-6" />}
       </button>
     </div>
   );

--- a/app/components/ThemeSwitcher.tsx
+++ b/app/components/ThemeSwitcher.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from "react";
 import { MdOutlineLightMode, MdOutlineDarkMode } from "react-icons/md";
 import { AiOutlineLoading3Quarters } from "react-icons/ai";
+import { AiOutlineLoading3Quarters } from "react-icons/ai";
 
 export default function ThemeSwitcher() {
   const [nowTheme, setNowTheme] = useState<string>();
+  const [isChanging, setIsChanging] = useState(false);
   const [isChanging, setIsChanging] = useState(false);
 
   useEffect(() => {
@@ -23,12 +25,23 @@ export default function ThemeSwitcher() {
     setNowTheme(newTheme);
     document.querySelector("html")?.setAttribute("data-theme", newTheme);
     setTimeout(() => setIsChanging(false), 500);
+    setTimeout(() => setIsChanging(false), 500);
   };
 
   return (
     <div className="tooltip tooltip-bottom" data-tip={nowTheme === "dark" ? "ライトモードに切り替え" : "ダークモードに切り替え"}>
-      <button onClick={toggleTheme} type="button" className={`btn btn-circle ml-1 mt-1 ${isChanging ? 'animate-spin' : ''}`}>
-        {isChanging ? <AiOutlineLoading3Quarters className="w-6 h-6 animate-spin" /> : nowTheme === "dark" ? <MdOutlineLightMode className="w-6 h-6" /> : <MdOutlineDarkMode className="w-6 h-6" />}
+      <button
+        onClick={toggleTheme}
+        type="button"
+        className={`btn btn-circle ml-1 mt-1 ${isChanging ? "animate-spin" : ""}`}
+      >
+        {isChanging ? (
+          <AiOutlineLoading3Quarters className="w-6 h-6 animate-spin" />
+        ) : nowTheme === "dark" ? (
+          <MdOutlineLightMode className="w-6 h-6" />
+        ) : (
+          <MdOutlineDarkMode className="w-6 h-6" />
+        )}
       </button>
     </div>
   );

--- a/app/components/ThemeSwitcher.tsx
+++ b/app/components/ThemeSwitcher.tsx
@@ -1,11 +1,9 @@
 import { useEffect, useState } from "react";
 import { MdOutlineLightMode, MdOutlineDarkMode } from "react-icons/md";
 import { AiOutlineLoading3Quarters } from "react-icons/ai";
-import { AiOutlineLoading3Quarters } from "react-icons/ai";
 
 export default function ThemeSwitcher() {
   const [nowTheme, setNowTheme] = useState<string>();
-  const [isChanging, setIsChanging] = useState(false);
   const [isChanging, setIsChanging] = useState(false);
 
   useEffect(() => {
@@ -24,7 +22,6 @@ export default function ThemeSwitcher() {
     window.localStorage.setItem("theme", newTheme);
     setNowTheme(newTheme);
     document.querySelector("html")?.setAttribute("data-theme", newTheme);
-    setTimeout(() => setIsChanging(false), 500);
     setTimeout(() => setIsChanging(false), 500);
   };
 

--- a/app/routes/_layout._index.tsx
+++ b/app/routes/_layout._index.tsx
@@ -35,7 +35,7 @@ export default function Feed() {
     const { mostRecentPosts, recentVotedPosts, communityPosts, famedPosts, mostRecentComments } = useLoaderData<typeof loader>();
     return (
         <>
-        <div>
+        <div className="container mx-auto">
             <div className="latest-posts">
                 <H2>最新の投稿</H2>
                 {mostRecentPosts.map((post) => (
@@ -51,12 +51,14 @@ export default function Feed() {
                         identifier="latest"
                     />
                 ))}
-                <NavLink
-                    to="/feed?p=2&type=timeDesc"
-                    className="rounded-md block w-full px-4 py-2 text-center btn-secondary my-4"
-                >
-                最新の投稿を見る
-                </NavLink>
+                <div className="mx-auto w-1/2">
+                    <NavLink
+                        to="/feed?p=2&type=timeDesc"
+                        className="rounded-md block px-10 py-2 text-center btn-secondary my-4"
+                    >
+                    最新の投稿を見る
+                    </NavLink>
+                </div>
             </div>
             <div className="recent-voted-posts">
             <H2>最近いいねされた投稿</H2>
@@ -73,12 +75,14 @@ export default function Feed() {
                         identifier="voted"
                     />
                 ))}
-                <NavLink
-                    to="/feed?p=2&likeFrom=24&likeTo=0&type=like"
-                    className="rounded-md block w-full px-4 py-2 text-center btn-secondary my-4"
-                >
-                最近いいねされた投稿を見る
-                </NavLink>
+                <div className="mx-auto w-1/2">
+                    <NavLink
+                        to="/feed?p=2&likeFrom=24&likeTo=0&type=like"
+                        className="rounded-md block w-full px-4 py-2 text-center btn-secondary my-4"
+                    >
+                    最近いいねされた投稿を見る
+                    </NavLink>
+                </div>
             </div>
             <div className="recent-comments">
                 <H2>最新のコメント</H2>

--- a/app/routes/_layout._index.tsx
+++ b/app/routes/_layout._index.tsx
@@ -94,19 +94,21 @@ function PostSection({ title, posts, identifier, children }: PostSectionProps) {
     return (
         <section className={`${identifier}-posts`}>
             <H2>{title}</H2>
-            {posts.map((post) => (
-                <PostCard
-                    key={`${identifier}-${post.postId}`}
-                    postId={post.postId}
-                    postTitle={post.postTitle}
-                    postDateGmt={post.postDateGmt}
-                    tagNames={post.tags.map((tag) => tag.tagName)}
-                    countLikes={post.countLikes}
-                    countDislikes={post.countDislikes}
-                    countComments={post.countComments}
-                    identifier={identifier}
-                />
-            ))}
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                {posts.map((post) => (
+                    <PostCard
+                        key={`${identifier}-${post.postId}`}
+                        postId={post.postId}
+                        postTitle={post.postTitle}
+                        postDateGmt={post.postDateGmt}
+                        tagNames={post.tags.map((tag) => tag.tagName)}
+                        countLikes={post.countLikes}
+                        countDislikes={post.countDislikes}
+                        countComments={post.countComments}
+                        identifier={identifier}
+                    />
+                ))}
+            </div>
             {children}
         </section>
     );

--- a/app/routes/_layout._index.tsx
+++ b/app/routes/_layout._index.tsx
@@ -68,7 +68,7 @@ export default function Feed() {
     return (
         <div className="container mx-auto">
             <PostSection title="最新の投稿" posts={mostRecentPosts} identifier="latest">
-                <button className="rounded-md block w-full max-w-[800px] px-10 py-2 text-center btn-secondary my-4 bg-base-200 mx-auto" type="button">
+                <button className="rounded-md block w-full max-w-[800px] px-10 py-2 text-center my-4 bg-base-200 hover:bg-base-300 mx-auto" type="button">
                     <NavLink to="/feed?p=2&type=timeDesc" className="block w-full h-full">
                         最新の投稿を見る
                     </NavLink>
@@ -76,7 +76,7 @@ export default function Feed() {
             </PostSection>
 
             <PostSection title="最近いいねされた投稿" posts={recentVotedPosts} identifier="voted">
-                <button className="rounded-md block w-full max-w-[400px] px-4 py-2 text-center btn-secondary my-4 bg-base-200 mx-auto" type="button">
+                <button className="rounded-md block w-full max-w-[400px] px-4 py-2 text-center my-4 bg-base-200 mx-auto hover:bg-base-300" type="button">
                     <NavLink to="/feed?p=2&likeFrom=24&likeTo=0&type=like" className="block w-full h-full">
                         最近いいねされた投稿を見る
                     </NavLink>

--- a/app/routes/_layout._index.tsx
+++ b/app/routes/_layout._index.tsx
@@ -118,16 +118,18 @@ function CommentSection({ title, comments }: CommentSectionProps) {
     return (
         <section className="recent-comments">
             <H2>{title}</H2>
-            {comments.map((comment) => (
-                <CommentShowCard
-                    key={comment.commentId}
-                    commentContent={comment.commentContent}
-                    commentDateGmt={comment.commentDateGmt}
-                    commentAuthor={comment.commentAuthor}
-                    postId={comment.postId}
-                    dimPosts={comment.dimPosts}
-                />
-            ))}
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                {comments.map((comment) => (
+                    <CommentShowCard
+                        key={comment.commentId}
+                        commentContent={comment.commentContent}
+                        commentDateGmt={comment.commentDateGmt}
+                        commentAuthor={comment.commentAuthor}
+                        postId={comment.postId}
+                        dimPosts={comment.dimPosts}
+                    />
+                ))}
+            </div>
         </section>
     );
 }

--- a/app/routes/_layout._index.tsx
+++ b/app/routes/_layout._index.tsx
@@ -6,6 +6,36 @@ import PostCard from "~/components/PostCard";
 import { H2 } from "~/components/Headings";
 import CommentShowCard from "~/components/CommentShowCard";
 
+type Post = {
+    postId: number;
+    postTitle: string;
+    postDateGmt: string;
+    tags: { tagName: string }[];
+    countLikes: number;
+    countDislikes: number;
+    countComments: number;
+};
+  
+type Comment = {
+    commentId: number;
+    commentContent: string;
+    commentDateGmt: string;
+    commentAuthor: string;
+    postId: number;
+    dimPosts: boolean;
+};
+
+type PostSectionProps = {
+    title: string;
+    posts: Post[];
+    identifier: string;
+    children?: React.ReactNode;
+};
+
+type CommentSectionProps = {
+    title: string;
+    comments: Comment[];
+};
 
 export const meta: MetaFunction = () => {
     return [
@@ -31,105 +61,71 @@ export async function loader() {
 }
 
 
+
 export default function Feed() {
     const { mostRecentPosts, recentVotedPosts, communityPosts, famedPosts, mostRecentComments } = useLoaderData<typeof loader>();
+    
     return (
-        <>
         <div className="container mx-auto">
-            <div className="latest-posts">
-                <H2>最新の投稿</H2>
-                {mostRecentPosts.map((post) => (
-                    <PostCard
-                        key={post.postId}
-                        postId={post.postId}
-                        postTitle={post.postTitle}
-                        postDateGmt={post.postDateGmt}
-                        tagNames={post.tags.map((tag) => tag.tagName)}
-                        countLikes={post.countLikes}
-                        countDislikes={post.countDislikes}
-                        countComments={post.countComments}
-                        identifier="latest"
-                    />
-                ))}
-                <div className="mx-auto w-1/2">
-                    <NavLink
-                        to="/feed?p=2&type=timeDesc"
-                        className="rounded-md block px-10 py-2 text-center btn-secondary my-4"
-                    >
-                    最新の投稿を見る
+            <PostSection title="最新の投稿" posts={mostRecentPosts} identifier="latest">
+                <button className="rounded-md block w-full max-w-[800px] px-10 py-2 text-center btn-secondary my-4 bg-base-200 mx-auto" type="button">
+                    <NavLink to="/feed?p=2&type=timeDesc" className="block w-full h-full">
+                        最新の投稿を見る
                     </NavLink>
-                </div>
-            </div>
-            <div className="recent-voted-posts">
-            <H2>最近いいねされた投稿</H2>
-                {recentVotedPosts.map((post) => (
-                    <PostCard
-                        key={post.postId}
-                        postId={post.postId}
-                        postTitle={post.postTitle}
-                        postDateGmt={post.postDateGmt}
-                        tagNames={post.tags.map((tag) => tag.tagName)}
-                        countLikes={post.countLikes}
-                        countDislikes={post.countDislikes}
-                        countComments={post.countComments}
-                        identifier="voted"
-                    />
-                ))}
-                <div className="mx-auto w-1/2">
-                    <NavLink
-                        to="/feed?p=2&likeFrom=24&likeTo=0&type=like"
-                        className="rounded-md block w-full px-4 py-2 text-center btn-secondary my-4"
-                    >
-                    最近いいねされた投稿を見る
+                </button>
+            </PostSection>
+
+            <PostSection title="最近いいねされた投稿" posts={recentVotedPosts} identifier="voted">
+                <button className="rounded-md block w-full max-w-[400px] px-4 py-2 text-center btn-secondary my-4 bg-base-200 mx-auto" type="button">
+                    <NavLink to="/feed?p=2&likeFrom=24&likeTo=0&type=like" className="block w-full h-full">
+                        最近いいねされた投稿を見る
                     </NavLink>
-                </div>
-            </div>
-            <div className="recent-comments">
-                <H2>最新のコメント</H2>
-                {mostRecentComments.map((comment) => (
-                    <CommentShowCard
-                        key={comment.commentId}
-                        commentContent={comment.commentContent}
-                        commentDateGmt={comment.commentDateGmt}
-                        commentAuthor={comment.commentAuthor}
-                        postId={comment.postId}
-                        dimPosts={comment.dimPosts}
-                    />
-                ))}
-            </div>
-            <div className="community-posts">
-                <H2>コミュニティ選</H2>
-                {communityPosts.map((post) => (
-                    <PostCard
-                        key={post.postId}
-                        postId={post.postId}
-                        postTitle={post.postTitle}
-                        postDateGmt={post.postDateGmt}
-                        tagNames={post.tags.map((tag) => tag.tagName)}
-                        countLikes={post.countLikes}
-                        countDislikes={post.countDislikes}
-                        countComments={post.countComments}
-                        identifier="community"
-                    />
-                ))}
-            </div>
-            <div className="famed-posts">
-                <H2>殿堂入り</H2>
-                {famedPosts.map((post) => (
-                    <PostCard
-                        key={post.postId}
-                        postId={post.postId}
-                        postTitle={post.postTitle}
-                        postDateGmt={post.postDateGmt}
-                        tagNames={post.tags.map((tag) => tag.tagName)}
-                        countLikes={post.countLikes}
-                        countDislikes={post.countDislikes}
-                        countComments={post.countComments}
-                        identifier="famed"
-                    />
-                ))}
-            </div>
+                </button>
+            </PostSection>
+
+            <CommentSection title="最新のコメント" comments={mostRecentComments} />
+            <PostSection title="コミュニティ選" posts={communityPosts} identifier="community" />
+            <PostSection title="殿堂入り" posts={famedPosts} identifier="famed" />
         </div>
-    </>
+    );
+}
+
+function PostSection({ title, posts, identifier, children }: PostSectionProps) {
+    return (
+        <section className={`${identifier}-posts`}>
+            <H2>{title}</H2>
+            {posts.map((post) => (
+                <PostCard
+                    key={`${identifier}-${post.postId}`}
+                    postId={post.postId}
+                    postTitle={post.postTitle}
+                    postDateGmt={post.postDateGmt}
+                    tagNames={post.tags.map((tag) => tag.tagName)}
+                    countLikes={post.countLikes}
+                    countDislikes={post.countDislikes}
+                    countComments={post.countComments}
+                    identifier={identifier}
+                />
+            ))}
+            {children}
+        </section>
+    );
+}
+
+function CommentSection({ title, comments }: CommentSectionProps) {
+    return (
+        <section className="recent-comments">
+            <H2>{title}</H2>
+            {comments.map((comment) => (
+                <CommentShowCard
+                    key={comment.commentId}
+                    commentContent={comment.commentContent}
+                    commentDateGmt={comment.commentDateGmt}
+                    commentAuthor={comment.commentAuthor}
+                    postId={comment.postId}
+                    dimPosts={comment.dimPosts}
+                />
+            ))}
+        </section>
     );
 }

--- a/app/routes/_layout.archives.$postId.tsx
+++ b/app/routes/_layout.archives.$postId.tsx
@@ -190,13 +190,9 @@ export default function Component() {
       <div>
         <H1>{data.postTitle}</H1>
         <div>
-          <div className="grid grid-cols-[auto_1fr] gap-2 my-1 items-center">
-            <div className="w-6 h-6">
-              <ClockIcon />
-            </div>
-            <p>
-              <RelativeDate timestamp={data.postDateGmt} />
-            </p>
+          <div className="flex items-start gap-2 my-1">
+            <div className="w-6 h-6"><ClockIcon /></div>
+            <RelativeDate timestamp={data.postDateGmt} />
           </div>
           <div className="grid grid-cols-[auto_1fr] gap-2 mb-2 items-center">
             <div className="w-6 h-6">

--- a/app/routes/_layout.login.tsx
+++ b/app/routes/_layout.login.tsx
@@ -1,4 +1,4 @@
-import { MetaFunction } from "@remix-run/node";
+import type { MetaFunction } from "@remix-run/node";
 import { SignIn } from "@clerk/remix";
 
 export default function login() {

--- a/app/routes/_layout.post.tsx
+++ b/app/routes/_layout.post.tsx
@@ -1,4 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import { Form, NavLink, useActionData, useLoaderData, useNavigate, useSubmit } from '@remix-run/react';
+import { json } from '@remix-run/node';
+import { useState, useEffect } from 'react';
+import { Turnstile } from '@marsidev/react-turnstile';
+import type { ActionFunctionArgs, MetaFunction } from '@remix-run/node';
+
 import DynamicTextInput from '~/components/SubmitFormComponents/DynamicTextInput';
 import TagSelectionBox from '~/components/SubmitFormComponents/TagSelectionBox';
 import SituationInput from '~/components/SubmitFormComponents/SituationInput';
@@ -10,14 +15,11 @@ import UserExplanation from '~/components/SubmitFormComponents/UserExplanation';
 import ValidationCheckBox from '~/components/SubmitFormComponents/ValidationCheckBox';
 import TextTypeSwitcher from '~/components/SubmitFormComponents/TextTypeSwitcher';
 import ClearLocalStorageButton from '~/components/SubmitFormComponents/ClearLocalStorageButton';
-import { ActionFunctionArgs, json } from '@remix-run/node';
-import { Form, MetaFunction, NavLink, useActionData, useLoaderData, useNavigate, useSubmit } from '@remix-run/react';
-import { prisma } from '~/modules/db.server';
-import { Turnstile } from '@marsidev/react-turnstile';
-import { getClientIPAddress } from 'remix-utils/get-client-ip-address';
-import { createEmbedding } from '~/modules/embedding.server';
 import { Modal } from '~/components/Modal';
 
+import { prisma } from '~/modules/db.server';
+import { getClientIPAddress } from 'remix-utils/get-client-ip-address';
+import { createEmbedding } from '~/modules/embedding.server';
 
 interface Tag {
     tagName: string;

--- a/app/routes/_layout.post.tsx
+++ b/app/routes/_layout.post.tsx
@@ -67,10 +67,10 @@ export default function Component() {
     const submit = useSubmit();
 
     useEffect(() => {
-        if (actionData?.success == false) {
+        if (actionData?.success === false) {
           setShowErrorModal(true);
           setIsSubmitting(false);
-        } else if (actionData?.success == true) {
+        } else if (actionData?.success === true) {
           setShowSuccessModal(true);
           setTimeout(() => {
             clearInputs();
@@ -193,7 +193,7 @@ export default function Component() {
     <div className="templateSubmitForm">
         <Form method="post" onSubmit={handleSubmit}>
         <UserExplanation />
-        <br></br>
+        <br/>
         <NavLink
             className="inline-block align-baseline font-bold text-sm text-info underline underline-offset-4"
             to="/freeStylePost"
@@ -205,15 +205,15 @@ export default function Component() {
             parentComponentStateValues={situationValues}
             selectedType={selectedType}
         />
-        <br></br>
-        <br></br>
+        <br/>
+        <br/>
         <DynamicTextInput
             description='書ききれなかった前提条件はありますか？'
             onInputChange={handleAssumptionChange}
             parentComponentStateValues={assumptionValues}
         />
-        <br></br>
-        <br></br>
+        <br/>
+        <br/>
         {selectedType === 'misDeed' ? (
             <>
             <StaticTextInput
@@ -269,7 +269,7 @@ export default function Component() {
             counterFactualReflectionValues={counterFactualReflectionValues}
             noteValues={noteValues}
         />
-        <br></br>
+        <br/>
         <StaticTextInput
             row={1}
             title='タイトル'
@@ -282,7 +282,7 @@ export default function Component() {
             parentComponentStateValues={selectedTags}
             allTagsOnlyForSearch={allTagsOnlyForSearch}
         />
-        <br></br>
+        <br/>
         <TagCreateBox
             handleTagCreated={handleTagCreated}
             handleTagRemoved={handleTagRemoved}
@@ -384,9 +384,9 @@ export async function action({ request }:ActionFunctionArgs ) {
           </ul>
         ` : ''}
         <h3>
-          ${selectedType == 'misDeed'
+          ${selectedType === 'misDeed'
             ? '健常行動ブレイクポイント'
-            : selectedType == 'goodDeed'
+            : selectedType === 'goodDeed'
             ? 'なぜやってよかったのか'
             : ''}
         </h3>
@@ -395,9 +395,9 @@ export async function action({ request }:ActionFunctionArgs ) {
         </ul>
 
         <h3>
-          ${selectedType == 'misDeed'
+          ${selectedType === 'misDeed'
             ? 'どうすればよかったか'
-            : selectedType == 'goodDeed'
+            : selectedType === 'goodDeed'
             ? 'やらなかったらどうなっていたか'
             : ''}
         </h3>
@@ -488,7 +488,7 @@ export const meta: MetaFunction = () => {
     const ogType = "article";
     const ogTitle = title;
     const ogDescription = description;
-    const ogUrl = `https://healthy-person-emulator.org/post`;
+    const ogUrl = "https://healthy-person-emulator.org/post";
     const twitterCard = "summary"
     const twitterSite = "@helthypersonemu"
     const twitterTitle = title

--- a/app/routes/_layout.signup.tsx
+++ b/app/routes/_layout.signup.tsx
@@ -1,4 +1,4 @@
-import { MetaFunction } from "@remix-run/node";
+import type { MetaFunction } from "@remix-run/node";
 import { SignUp } from "@clerk/remix";
 
 export default function Component() {

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -60,14 +60,32 @@ export default function Component() {
   return (
     <div className="grid grid-cols-1 min-h-screen">
       <div className="hidden md:block">
-        <header className="navbar fixed z-10 border-b p-4 border-base-200  bg-base-100 grid grid-cols-[1fr,2fr,1fr]">
+        <header className="navbar z-10 border-b p-4 border-base-200  bg-base-100 grid grid-cols-[2fr,10fr,1fr]">
           <div>
-            <h1 className="text-xl font-bold">
+            <h1 className="text-lg font-bold">
             <NavLink to="/">健常者エミュレータ事例集</NavLink>
             </h1>
           </div>
           <div className="flex justify-center">
             <ThemeSwitcher />
+            <ul className="flex gap-x-4">
+              {navItems.map((item) => {
+                if (item.to === "/logout"){
+                  return (
+                    <li key={item.to} className="hover:font-bold rounded-lg">
+                      <SignOutButton redirectUrl="/">
+                        ログアウト
+                      </SignOutButton>
+                    </li>
+                  )
+                }
+                return (
+                  <li key={item.to} className="hover:font-bold rounded-lg">
+                    <NavLink to={item.to}>{item.text}</NavLink>
+                  </li>
+                )
+              })}
+            </ul>
           </div>
           <div className="flex justify-end" >
             <div className="tooltip tooltip-bottom" data-tip="検索する">

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -234,7 +234,7 @@ export default function Component() {
       <div className="tooltip tooltip-top fixed bottom-10 right-10" data-tip="投稿する">
         <NavLink to="/post">
           <button className="btn btn-primary btn-circle" type="button">
-            <MdOutlinePostAdd className="text-4xl" />
+            <PostIcon />
           </button>
         </NavLink>
       </div>

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -64,52 +64,52 @@ function renderSearchModal(){
 
 function renderDesktopHeader(navItems: ReturnType<typeof getNavItems>){
   return (
-    <header className="navbar z-10 border-b p-4 border-base-200 bg-base-100 grid grid-cols-[2fr,10fr,1fr]">
-    <div>
-      <h1 className="text-lg font-bold">
-        <NavLink to="/">健常者エミュレータ事例集</NavLink>
-      </h1>
-    </div>
-    <div className="flex justify-center">
-      <ThemeSwitcher />
-      <ul className="flex gap-x-4">
-        {navItems.map((item) => (
-          <li key={item.to} className="hover:font-bold rounded-lg">
-            {item.to === "/logout" ? (
-              <SignOutButton redirectUrl="/">ログアウト</SignOutButton>
-            ) : (
-              <NavLink to={item.to}>{item.text}</NavLink>
-            )}
-          </li>
-        ))}
-      </ul>
-    </div>
-    <div className="flex justify-end">
-      <div className="tooltip tooltip-bottom" data-tip="検索する">
-        <button className="btn btn-ghost" onClick={() => {
-          const searchModal = document?.getElementById('search-modal') as HTMLDialogElement;
-          searchModal?.showModal();
-        }} type="button">
-          <MdSearch />
-        </button>
-        {renderSearchModal()}
+    <header className="navbar z-10 border-b p-4 border-base-200 bg-base-100 flex justify-between items-center">
+      <div className="flex-none">
+        <h1 className="text-lg font-bold">
+          <NavLink to="/">健常者エミュレータ事例集</NavLink>
+        </h1>
       </div>
-    </div>
-  </header>
-);
+      <div className="flex-1 flex justify-center items-center">
+        <ThemeSwitcher />
+        <ul className="flex flex-wrap justify-center gap-x-2 gap-y-1 mx-2">
+          {navItems.map((item) => (
+            <li key={item.to} className="hover:font-bold rounded-lg hover:bg-base-200 py-2">
+              {item.to === "/logout" ? (
+                <SignOutButton redirectUrl="/">ログアウト</SignOutButton>
+              ) : (
+                <NavLink to={item.to} className="px-2 py-1 text-sm">{item.text}</NavLink>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="flex-none">
+        <div className="tooltip tooltip-bottom" data-tip="検索する">
+          <button className="btn btn-ghost" onClick={() => {
+            const searchModal = document?.getElementById('search-modal') as HTMLDialogElement;
+            searchModal?.showModal();
+          }} type="button">
+            <MdSearch />
+          </button>
+          {renderSearchModal()}
+        </div>
+      </div>
+    </header>
+  );
 }
 
 function renderMobileHeader(navItems: ReturnType<typeof getNavItems>){
   return (
-    <header className="navbar fixed z-10 border-b p-4 border-base-200 bg-base-100 grid grid-cols-2">
-    <div>
-      <h1 className="text-xl font-bold">
-        <NavLink to="/">健エミュ</NavLink>
-      </h1>
-    </div>
-    <div>
-      <div className="drawer drawer-end">
-        <input id="drawer-toggle" type="checkbox" className="drawer-toggle" />
+    <header className="navbar fixed z-10 border-b p-4 border-base-200 bg-base-100 flex justify-between">
+      <div>
+        <h1 className="text-xl font-bold">
+          <NavLink to="/">健常者エミュレータ事例集</NavLink>
+        </h1>
+      </div>
+      <div>
+        <div className="drawer drawer-end">
+          <input id="drawer-toggle" type="checkbox" className="drawer-toggle" />
         <div className="drawer-content flex justify-end">
           <label htmlFor="drawer-toggle" className="btn btn-ghost">
             <MdMenu />

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -14,6 +14,9 @@ import MenuIcon from "~/components/icons/MenuIcon";
 import TopIcon from "~/components/icons/TopIcon";
 import ThumbsUpIcon from "~/components/icons/ThumbsUpIcon";
 import { useUser, SignOutButton } from "@clerk/remix";
+import { MdOutlinePostAdd, MdSearch } from "react-icons/md";
+import { H3 } from "~/components/Headings";
+import { useEffect } from "react";
 
 export default function Component() {
   const { isSignedIn } = useUser();
@@ -74,29 +77,64 @@ export default function Component() {
     );
   };
 
+  const searchModal = document.getElementById('search-modal') as HTMLDialogElement;
+
+  useEffect(()=> {
+    const handleKeyDownForSearch = (event: KeyboardEvent) => {
+      if (event.ctrlKey && event.key === "f") {
+        event.preventDefault();
+        searchModal?.showModal();
+      }
+    }
+    window.addEventListener('keydown', handleKeyDownForSearch);
+    return () => window.removeEventListener('keydown', handleKeyDownForSearch);
+  }, [searchModal]);
+
   return (
     <div className="grid grid-cols-1 min-h-screen">
-      <header className="fixed top-0 w-full bg-base-100 shadow z-10">
-        <div className="container mx-auto px-4">
-          <div className="flex justify-between items-center py-4">
-            <div className="flex items-center space-x-4">
-              <h1 className="text-xl font-bold hidden md:block">
-                <NavLink to="/">健常者エミュレータ事例集</NavLink>
-              </h1>
-              <Form method="post" action="/search" className="flex items-center">
-                <input type="text" placeholder="検索" className="input input-bordered w-40 md:w-64 p-2 rounded-lg" name="query"/>
-                <button className="btn btn-square btn-ghost ml-2" title="search" type="submit">
-                  <SearchIcon/> 
-                </button>
-                <input type="hidden" name="action" value="firstSearch"/>
-              </Form>
-            </div>
-            <ThemeSwitcher />
+      <header className="navbar fixed z-10 border-b p-4 border-base-200  bg-base-100 grid grid-cols-[1fr,2fr,1fr]">
+        <div>
+          <h1 className="text-xl font-bold hidden md:block">
+            <NavLink to="/">健常者エミュレータ事例集</NavLink>
+          </h1>
+          <h1 className="text-xl font-bold block md:hidden">
+            <NavLink to="/">健エミュ</NavLink>
+          </h1>
+        </div>
+        <div className="hidden md:flex md:justify-center">
+          <ThemeSwitcher />
+        </div>
+        <div className="flex justify-end" >
+          <div className="tooltip tooltip-bottom" data-tip="検索する">
+            <button className="btn btn-ghost" onClick={()=>searchModal?.showModal()} type="button">
+              <MdSearch />
+            </button>
+            <dialog id="search-modal" className="modal">
+              <div className="modal-box">
+                <div className="mt-6">
+                  <Form method="post" action="/search" className="flex flex-row" onSubmit={()=>{
+                    searchModal?.close();
+                  }}>
+                    <input type="text" name="query" placeholder="検索する..." className="input input-bordered w-full placeholder-slate-500"/>
+                      <button type="submit" className="btn btn-primary ml-4">
+                        <MdSearch />
+                      </button>
+                    <input type="hidden" name="action" value="firstSearch" />
+                    <form method="dialog">
+                      <button type="submit" className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
+                    </form>
+                  </Form>
+                </div>
+              </div>
+              <form method="dialog" className="modal-backdrop">
+                <button type="submit">閉じる</button>
+              </form>
+            </dialog>
           </div>
         </div>
       </header>
-
       <main className="grid md:grid-cols-[auto,1fr] pt-16">
+        {/* md以上の画面サイズ向けメニュー */}
         <nav className="hidden md:block w-64 bg-base-100 border-r border-neutral">
           <div className="fixed top-32 bottom-0 w-64 p-4 overflow-y-auto">
             <ul className="space-y-4">
@@ -122,46 +160,14 @@ export default function Component() {
           <Outlet />
         </div>
       </main>
-
-      <nav className="fixed bottom-0 w-full bg-base-100 shadow-inner md:hidden">
-        <ul className="flex justify-between items-center p-4">
-          {navItems.map(item => (
-            <li key={item.to}>
-              {item.to === "/post" ? (
-                <NavLink to="/post" className="flex flex-col items-center btn-primary px-2 py-2 rounded-3xl">
-                  <PostIcon />
-                  <p className="text-xs font-bold">投稿する</p>
-                </NavLink>
-              ) : (
-                renderNavItem(item)
-              )}
-            </li>
-          ))}
-          <li>
-            <div className="drawer">
-              <input id="menu-drawer" type="checkbox" className="drawer-toggle" />
-              <div className="drawer-content flex flex-col items-center">
-                <MenuIcon />
-                <label htmlFor="menu-drawer" className="drawer-overlay">メニュー</label>
-              </div>
-              <div className="drawer-side">
-                <label htmlFor="menu-drawer" aria-label="close sidebar" className="drawer-overlay" />
-                <ul className="menu pt-32 w-80 min-h-full bg-base-100 text-base-content">
-                  {menuItems.map((item) => (
-                    <li key={item.to}>
-                      <NavLink to={item.to} className="flex items-center p-2 rounded" onClick={() => document.getElementById("menu-drawer")?.click()}>
-                        <item.icon />
-                        <p className="ml-2">{item.text}</p>
-                      </NavLink>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            </div>
-          </li>
-        </ul>
-      </nav>
-
+      {/* md以下の画面サイズ向けメニュー */}
+      <div className="md:hidden tooltip tooltip-top fixed bottom-10 right-10" data-tip="投稿する">
+        <NavLink to="/post">
+          <button className="btn btn-primary btn-circle" type="button">
+            <MdOutlinePostAdd className="text-4xl" />
+          </button>
+        </NavLink>
+      </div>
       <footer className="bg-base-100 py-8 md:py-4">
         <div className="container mx-auto px-4">
           <div className="flex justify-center items-center">

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -101,7 +101,7 @@ function renderDesktopHeader(navItems: ReturnType<typeof getNavItems>){
 
 function renderMobileHeader(navItems: ReturnType<typeof getNavItems>){
   return (
-    <header className="navbar fixed z-10 border-b p-4 border-base-200 bg-base-100 flex justify-between">
+    <header className="navbar fixed z-50 border-b p-4 border-base-200 bg-base-100 flex justify-between">
       <div>
         <h1 className="text-xl font-bold">
           <NavLink to="/">健常者エミュレータ事例集</NavLink>
@@ -117,7 +117,7 @@ function renderMobileHeader(navItems: ReturnType<typeof getNavItems>){
         </div>
         <div className="drawer-side">
           <label htmlFor="drawer-toggle" className="drawer-overlay"/>
-          <div className="bg-base-100">
+          <div className="bg-base-200">
             <button
               className="btn btn-ghost absolute right-4 top-2"
               type="button"

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -10,12 +10,10 @@ import GuidelineIcon from "~/components/icons/GuidelineIcon";
 import LogoutIcon from "~/components/icons/LogoutIcon";
 import SignupIcon from "~/components/icons/SignupIcon";
 import LoginIcon from "~/components/icons/LoginIcon";
-import MenuIcon from "~/components/icons/MenuIcon";
 import TopIcon from "~/components/icons/TopIcon";
 import ThumbsUpIcon from "~/components/icons/ThumbsUpIcon";
 import { useUser, SignOutButton } from "@clerk/remix";
 import { MdOutlinePostAdd, MdSearch, MdMenu } from "react-icons/md";
-import { H3 } from "~/components/Headings";
 import { useEffect } from "react";
 
 

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -102,7 +102,7 @@ function renderDesktopHeader(navItems: ReturnType<typeof getNavItems>){
 
 function renderMobileHeader(navItems: ReturnType<typeof getNavItems>){
   return (
-    <header className="navbar fixed z-40 border-b p-4 border-base-200 bg-base-100 flex justify-between">
+    <header className="navbar fixed z-40 border-b px-2 border-base-200 bg-base-100 flex justify-between">
       <div>
         <h1 className="text-xl font-bold">
           <NavLink to="/">健常者エミュレータ事例集</NavLink>

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -233,7 +233,7 @@ export default function Component() {
       </main>
       <div className="tooltip tooltip-top fixed bottom-10 right-10" data-tip="投稿する">
         <NavLink to="/post">
-          <button className="btn btn-primary btn-circle" type="button">
+          <button className="btn btn-primary btn-circle btn-lg" type="button">
             <PostIcon />
           </button>
         </NavLink>

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -93,7 +93,6 @@ function renderDesktopHeader(navItems: ReturnType<typeof getNavItems>){
           }} type="button">
             <SearchIcon />
           </button>
-          {renderSearchModal()}
         </div>
       </div>
     </header>
@@ -109,56 +108,66 @@ function renderMobileHeader(navItems: ReturnType<typeof getNavItems>){
         </h1>
       </div>
       <div>
-        <div className="drawer drawer-end">
-          <input id="drawer-toggle" type="checkbox" className="drawer-toggle" />
-        <div className="drawer-content flex justify-end">
-          <label htmlFor="drawer-toggle" className="btn btn-ghost">
-            <MenuIcon />
-          </label>
+        <div className="tooltip tooltip-bottom" data-tip="検索する">
+          <button className="btn btn-ghost" onClick={() => {
+            const searchModal = document?.getElementById('search-modal') as HTMLDialogElement;
+            searchModal?.showModal();
+          }} type="button">
+            <SearchIcon />
+          </button>
         </div>
-        <div className="drawer-side">
-          <label htmlFor="drawer-toggle" className="drawer-overlay"/>
-          <div className="bg-base-200">
-            <button
-              className="btn btn-ghost absolute right-4 top-2"
-              type="button"
-              onClick={() => {
-                document.getElementById('drawer-toggle')?.click();
-              }}
-            >
-              ✕
-            </button>
-            <div className="mt-3 ml-2">
-              <ThemeSwitcher />
+        <div>
+          <div className="drawer drawer-end">
+            <input id="drawer-toggle" type="checkbox" className="drawer-toggle" />
+          <div className="drawer-content flex justify-end">
+            <label htmlFor="drawer-toggle" className="btn btn-ghost">
+              <MenuIcon />
+            </label>
+          </div>
+          <div className="drawer-side">
+            <label htmlFor="drawer-toggle" className="drawer-overlay"/>
+            <div className="bg-base-200">
+              <button
+                className="btn btn-ghost absolute right-4 top-2"
+                type="button"
+                onClick={() => {
+                  document.getElementById('drawer-toggle')?.click();
+                }}
+              >
+                ✕
+              </button>
+              <div className="mt-3 ml-2">
+                <ThemeSwitcher />
+              </div>
+              <ul className="p-4 w-50 text-base-content min-h-screen py-1 flex flex-col">
+                {navItems.map((item) => (
+                  <li key={item.to} className="justify-center">
+                    {item.to === "/logout" ? (
+                      <button onClick={() => {
+                        document.getElementById('drawer-toggle')?.click();
+                      }}
+                      className="flex gap-x-3 my-3 hover:bg-base-200 rounded-lg p-2"
+                      type="button"
+                      >
+                        <LogoutIcon/>
+                        <SignOutButton redirectUrl="/">
+                          {"ログアウト"}
+                        </SignOutButton>
+                      </button>
+                    ) : (
+                      <NavLink to={item.to} onClick={() => {
+                        document.getElementById('drawer-toggle')?.click();
+                      }}
+                      className="flex gap-x-3 my-3 hover:bg-base-200 rounded-lg p-2"
+                      >
+                        <item.icon />
+                        {item.text}
+                      </NavLink>
+                    )}
+                  </li>
+                ))}
+              </ul>
             </div>
-            <ul className="p-4 w-50 text-base-content min-h-screen py-1 flex flex-col">
-              {navItems.map((item) => (
-                <li key={item.to} className="justify-center">
-                  {item.to === "/logout" ? (
-                    <button onClick={() => {
-                      document.getElementById('drawer-toggle')?.click();
-                    }}
-                    className="flex gap-x-3 my-3 hover:bg-base-200 rounded-lg p-2"
-                    type="button"
-                    >
-                      <LogoutIcon/>
-                      <SignOutButton redirectUrl="/">
-                        {"ログアウト"}
-                      </SignOutButton>
-                    </button>
-                  ) : (
-                    <NavLink to={item.to} onClick={() => {
-                      document.getElementById('drawer-toggle')?.click();
-                    }}
-                    className="flex gap-x-3 my-3 hover:bg-base-200 rounded-lg p-2"
-                    >
-                      <item.icon />
-                      {item.text}
-                    </NavLink>
-                  )}
-                </li>
-              ))}
-            </ul>
           </div>
         </div>
       </div>
@@ -192,6 +201,7 @@ export default function Component() {
       <div className="block md:hidden">
         {renderMobileHeader(navItems)}
       </div>
+      {renderSearchModal()}
       <main className="p-4 xl:mx-10 2xl:mx-96 overflow-x-hidden">
         <div className="pt-16">
           <Outlet />

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -1,7 +1,7 @@
-import { Form, Outlet } from "@remix-run/react";
-import { NavLink } from "react-router-dom";
-import ThemeSwitcher from "~/components/ThemeSwitcher";
-import HomeIcon from "~/components/icons/HomeIcon";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Form, Outlet, NavLink } from "@remix-run/react";
+import { useUser, SignOutButton } from "@clerk/remix";
+
 import RandomIcon from "~/components/icons/RandomIcon";
 import PostIcon from "~/components/icons/PostIcon";
 import SearchIcon from "~/components/icons/SearchIcon";
@@ -12,10 +12,10 @@ import SignupIcon from "~/components/icons/SignupIcon";
 import LoginIcon from "~/components/icons/LoginIcon";
 import TopIcon from "~/components/icons/TopIcon";
 import ThumbsUpIcon from "~/components/icons/ThumbsUpIcon";
-import { useUser, SignOutButton } from "@clerk/remix";
-import { MdOutlinePostAdd } from "react-icons/md";
-import { useCallback, useEffect, useRef, useState } from "react";
 import MenuIcon from "~/components/icons/MenuIcon";
+
+import ThemeSwitcher from "~/components/ThemeSwitcher";
+
 
 function getNavItems(isSignedIn: boolean){
   const items = [

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -130,7 +130,10 @@ export default function Component() {
                   >
                   ✕
                   </button>
-                  <ul className="p-4 w-50 text-base-content min-h-screen py-20 flex flex-col">
+                  <div className="mt-2">
+                    <ThemeSwitcher />
+                  </div>
+                  <ul className="p-4 w-50 text-base-content min-h-screen py-24 flex flex-col">
                     {navItems.map((item) => {
                       return (
                         <li key={item.to} className="justify-center">

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -204,7 +204,7 @@ export default function Component() {
       </div>
       {renderSearchModal()}
       <main className="p-4 xl:mx-10 2xl:mx-96 overflow-x-hidden">
-        <div className="pt-16">
+        <div>
           <Outlet />
         </div>
       </main>

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -15,6 +15,7 @@ import ThumbsUpIcon from "~/components/icons/ThumbsUpIcon";
 import { useUser, SignOutButton } from "@clerk/remix";
 import { MdOutlinePostAdd, MdSearch, MdMenu } from "react-icons/md";
 import { useEffect } from "react";
+import MenuIcon from "~/components/icons/MenuIcon";
 
 function getNavItems(isSignedIn: boolean){
   const items = [
@@ -46,7 +47,7 @@ function renderSearchModal(){
         }}>
           <input type="text" name="query" placeholder="検索する..." className="input input-bordered w-full placeholder-slate-500"/>
           <button type="submit" className="btn btn-primary ml-4">
-            <MdSearch />
+            <SearchIcon />
           </button>
           <input type="hidden" name="action" value="firstSearch" />
           <form method="dialog">
@@ -90,7 +91,7 @@ function renderDesktopHeader(navItems: ReturnType<typeof getNavItems>){
             const searchModal = document?.getElementById('search-modal') as HTMLDialogElement;
             searchModal?.showModal();
           }} type="button">
-            <MdSearch />
+            <SearchIcon />
           </button>
           {renderSearchModal()}
         </div>
@@ -101,7 +102,7 @@ function renderDesktopHeader(navItems: ReturnType<typeof getNavItems>){
 
 function renderMobileHeader(navItems: ReturnType<typeof getNavItems>){
   return (
-    <header className="navbar fixed z-50 border-b p-4 border-base-200 bg-base-100 flex justify-between">
+    <header className="navbar fixed z-40 border-b p-4 border-base-200 bg-base-100 flex justify-between">
       <div>
         <h1 className="text-xl font-bold">
           <NavLink to="/">健常者エミュレータ事例集</NavLink>
@@ -112,7 +113,7 @@ function renderMobileHeader(navItems: ReturnType<typeof getNavItems>){
           <input id="drawer-toggle" type="checkbox" className="drawer-toggle" />
         <div className="drawer-content flex justify-end">
           <label htmlFor="drawer-toggle" className="btn btn-ghost">
-            <MdMenu />
+            <MenuIcon />
           </label>
         </div>
         <div className="drawer-side">

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -193,7 +193,7 @@ export default function Component() {
         {renderMobileHeader(navItems, handleSearchModalOpen)}
       </div>
       <dialog id="search-modal" className={`modal ${isSearchModalOpen ? "modal-open" : ""}`}>
-      <div className="modal-box">
+      <div className="modal-box absolute top-[25%] transform -translate-y-1/2">
         <div className="mt-6">
           <Form method="post" action="/search" className="flex flex-row" onSubmit={() => {
             handleSearchModalOpen(false);
@@ -225,7 +225,7 @@ export default function Component() {
           handleSearchModalOpen(false);
         }}>閉じる</button>
       </form>
-    </dialog> 
+    </dialog>
       <main className="p-4 xl:mx-10 2xl:mx-96 overflow-x-hidden">
         <div>
           <Outlet />

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -38,7 +38,7 @@ function getNavItems(isSignedIn: boolean){
 
 function renderSearchModal(){
   return (
-    <dialog id="search-modal" className="modal">
+    <dialog id="search-modal" className="modal -top-1/4">
     <div className="modal-box">
       <div className="mt-6">
         <Form method="post" action="/search" className="flex flex-row" onSubmit={() => {

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -133,34 +133,11 @@ export default function Component() {
           </div>
         </div>
       </header>
-      <main className="grid md:grid-cols-[auto,1fr] pt-16">
-        {/* md以上の画面サイズ向けメニュー */}
-        <nav className="hidden md:block w-64 bg-base-100 border-r border-neutral">
-          <div className="fixed top-32 bottom-0 w-64 p-4 overflow-y-auto">
-            <ul className="space-y-4">
-              {navItems.map((item) => item.to !== "/post" && (
-                <li key={item.to}>{renderNavItem(item)}</li>
-              ))}
-              {menuItems.map((item) => (
-                <li key={item.to}>{renderNavItem(item)}</li>
-              ))}
-              <li>
-                <NavLink
-                  to="/post"
-                  className="flex flex-col md:flex-row items-center bg-[#99D9EA] hover:bg-teal-100 text-slate-950 px-4 py-4 mt-20 rounded-full"
-                >
-                  <PostIcon />
-                  <p className="text-xs px-4 font-bold">投稿する</p>
-                </NavLink>
-              </li>
-            </ul>
-          </div>
-        </nav>
-        <div className="p-4 xl:mx-10 2xl:mx-96 overflow-x-hidden">
+      <main className="p-4 xl:mx-10 2xl:mx-96 overflow-x-hidden">
+        <div className="pt-16">
           <Outlet />
         </div>
       </main>
-      {/* md以下の画面サイズ向けメニュー */}
       <div className="tooltip tooltip-top fixed bottom-10 right-10" data-tip="投稿する">
         <NavLink to="/post">
           <button className="btn btn-primary btn-circle" type="button">

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -14,27 +14,26 @@ import MenuIcon from "~/components/icons/MenuIcon";
 import TopIcon from "~/components/icons/TopIcon";
 import ThumbsUpIcon from "~/components/icons/ThumbsUpIcon";
 import { useUser, SignOutButton } from "@clerk/remix";
-import { MdOutlinePostAdd, MdSearch } from "react-icons/md";
+import { MdOutlinePostAdd, MdSearch, MdMenu } from "react-icons/md";
 import { H3 } from "~/components/Headings";
 import { useEffect } from "react";
 
+
 export default function Component() {
   const { isSignedIn } = useUser();
+  console.log("isSignedIn", isSignedIn);
 
   const navItems = [
     { to: "/", icon: HomeIcon, text: "トップ" },
     { to: "/random", icon: RandomIcon, text: "ランダム" },
     { to: "/post", icon: PostIcon, text: "投稿する" },
     { to: "/search", icon: SearchIcon, text: "検索する" },
-  ];
-
-  const menuItems = [
     { to: "/support", text: "サポートする", icon: DonationIcon },
     { to: "/readme", text: "サイト説明", icon: GuidelineIcon },
     { to: "/feed?p=1&type=unboundedLikes", text: "無期限いいね順", icon: ThumbsUpIcon },
     ...(isSignedIn
       ? [{
-          to: "#",
+          to: "/logout",
           text: "ログアウト",
           icon: LogoutIcon,
         }]
@@ -44,42 +43,10 @@ export default function Component() {
         ]),
   ];
 
-  const renderNavItem = (item: { to: string; icon: React.ComponentType; text: string; onClick?: () => void }): JSX.Element => {
-    const content = (
-      <>
-        <item.icon />
-        <p className="text-xs md:text-sm md:ml-4">{item.text}</p>
-      </>
-    );
 
-    if (item.text === "ログアウト") {
-      return (
-        <SignOutButton redirectUrl="/">
-          <button className="flex items-center md:items-start md:flex-row flex-col text-base-content md:hover:bg-base-200 md:py-2 md:pr-4 md:pl-3 rounded md:ml-4 w-fit" type="button">
-            {content}
-          </button>
-        </SignOutButton>
-      );
-    }
-
-    return (
-      <NavLink
-        key={item.to}
-        to={item.to}
-        className={({ isActive }) =>
-          `flex items-center md:items-start md:flex-row flex-col text-base-content md:hover:bg-base-200 md:py-2 md:pr-4 md:pl-3 rounded md:ml-4 w-fit ${
-            isActive ? "font-bold md:bg-base-300" : ""
-          }`
-        }
-      >
-        {content}
-      </NavLink>
-    );
-  };
-
-  const searchModal = document.getElementById('search-modal') as HTMLDialogElement;
 
   useEffect(()=> {
+    const searchModal = document?.getElementById('search-modal') as HTMLDialogElement;
     const handleKeyDownForSearch = (event: KeyboardEvent) => {
       if (event.ctrlKey && event.key === "f") {
         event.preventDefault();
@@ -88,51 +55,124 @@ export default function Component() {
     }
     window.addEventListener('keydown', handleKeyDownForSearch);
     return () => window.removeEventListener('keydown', handleKeyDownForSearch);
-  }, [searchModal]);
+  }, []);
 
   return (
     <div className="grid grid-cols-1 min-h-screen">
-      <header className="navbar fixed z-10 border-b p-4 border-base-200  bg-base-100 grid grid-cols-[1fr,2fr,1fr]">
-        <div>
-          <h1 className="text-xl font-bold hidden md:block">
+      <div className="hidden md:block">
+        <header className="navbar fixed z-10 border-b p-4 border-base-200  bg-base-100 grid grid-cols-[1fr,2fr,1fr]">
+          <div>
+            <h1 className="text-xl font-bold">
             <NavLink to="/">健常者エミュレータ事例集</NavLink>
-          </h1>
-          <h1 className="text-xl font-bold block md:hidden">
+            </h1>
+          </div>
+          <div className="flex justify-center">
+            <ThemeSwitcher />
+          </div>
+          <div className="flex justify-end" >
+            <div className="tooltip tooltip-bottom" data-tip="検索する">
+              <button className="btn btn-ghost" onClick={()=>{
+                const searchModal = document?.getElementById('search-modal') as HTMLDialogElement;
+                searchModal?.showModal();
+              }} type="button">
+                <MdSearch />
+              </button>
+              <dialog id="search-modal" className="modal">
+                <div className="modal-box">
+                  <div className="mt-6">
+                    <Form method="post" action="/search" className="flex flex-row" onSubmit={()=>{
+                      const searchModal = document?.getElementById('search-modal') as HTMLDialogElement;
+                      searchModal?.close();
+                    }}>
+                      <input type="text" name="query" placeholder="検索する..." className="input input-bordered w-full placeholder-slate-500"/>
+                        <button type="submit" className="btn btn-primary ml-4">
+                          <MdSearch />
+                        </button>
+                      <input type="hidden" name="action" value="firstSearch" />
+                      <form method="dialog">
+                        <button type="submit" className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
+                      </form>
+                    </Form>
+                  </div>
+                </div>
+                <form method="dialog" className="modal-backdrop">
+                  <button type="submit">閉じる</button>
+                </form>
+              </dialog>
+            </div>
+          </div>
+        </header>
+      </div>
+      <div className="block md:hidden">
+        <header className="navbar fixed z-10 border-b p-4 border-base-200  bg-base-100 grid grid-cols-2">
+          <div>
+            <h1 className="text-xl font-bold">
             <NavLink to="/">健エミュ</NavLink>
-          </h1>
-        </div>
-        <div className="hidden md:flex md:justify-center">
-          <ThemeSwitcher />
-        </div>
-        <div className="flex justify-end" >
-          <div className="tooltip tooltip-bottom" data-tip="検索する">
-            <button className="btn btn-ghost" onClick={()=>searchModal?.showModal()} type="button">
-              <MdSearch />
-            </button>
-            <dialog id="search-modal" className="modal">
-              <div className="modal-box">
-                <div className="mt-6">
-                  <Form method="post" action="/search" className="flex flex-row" onSubmit={()=>{
-                    searchModal?.close();
-                  }}>
-                    <input type="text" name="query" placeholder="検索する..." className="input input-bordered w-full placeholder-slate-500"/>
-                      <button type="submit" className="btn btn-primary ml-4">
-                        <MdSearch />
-                      </button>
-                    <input type="hidden" name="action" value="firstSearch" />
-                    <form method="dialog">
-                      <button type="submit" className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
-                    </form>
-                  </Form>
+            </h1>
+          </div>
+          <div>
+            <div className="drawer drawer-end">
+              <input id="drawer-toggle" type="checkbox" className="drawer-toggle" />
+              <div className="drawer-content flex justify-end">
+                <label htmlFor="drawer-toggle" className="btn btn-ghost">
+                  <MdMenu />
+                </label>
+              </div>
+              <div className="drawer-side">
+                <label htmlFor="drawer-toggle" className="drawer-overlay"/>
+                <div className="bg-base-100">
+                  <button
+                    className="btn btn-ghost absolute right-4 top-2"
+                    type="button"
+                    onClick={() => {
+                      document.getElementById('drawer-toggle')?.click();
+                    }}
+                  >
+                  ✕
+                  </button>
+                  <ul className="p-4 w-50 text-base-content min-h-screen py-20 flex flex-col">
+                    {navItems.map((item) => {
+                      return (
+                        <li key={item.to} className="justify-center">
+                          {item.to === "/logout" && 
+                          (
+                            <button onClick={
+                              () => {
+                              document.getElementById('drawer-toggle')?.click();
+                            }}
+                              className="flex gap-x-3 my-3 hover:bg-base-200 rounded-lg p-2"
+                              type="button"
+                            >
+                            <LogoutIcon/>
+                            <SignOutButton redirectUrl="/">
+                            {"ログアウト"}
+                            </SignOutButton>
+                            </button>
+                          )
+                          }
+                          {item.to !== "/logout" &&
+                          <NavLink to={item.to} onClick={
+                            () => {
+                            document.getElementById('drawer-toggle')?.click();
+                          }}
+                          className="flex gap-x-3 my-3 hover:bg-base-200 rounded-lg p-2"
+                          >
+                            <item.icon />
+                            {item.text}
+                          </NavLink>
+                          }
+                        </li>
+                      )
+                    })}
+                  </ul>
                 </div>
               </div>
-              <form method="dialog" className="modal-backdrop">
-                <button type="submit">閉じる</button>
-              </form>
-            </dialog>
+            </div>
           </div>
-        </div>
-      </header>
+        </header>
+      </div>
+
+
       <main className="p-4 xl:mx-10 2xl:mx-96 overflow-x-hidden">
         <div className="pt-16">
           <Outlet />

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -50,9 +50,10 @@ function renderSearchModal(){
             <SearchIcon />
           </button>
           <input type="hidden" name="action" value="firstSearch" />
-          <form method="dialog">
-            <button type="submit" className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
-          </form>
+          <button type="button" className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2" onClick={() => {
+            const searchModal = document?.getElementById('search-modal') as HTMLDialogElement;
+            searchModal?.close();
+          }}>✕</button>
         </Form>
       </div>
     </div>
@@ -101,13 +102,13 @@ function renderDesktopHeader(navItems: ReturnType<typeof getNavItems>){
 
 function renderMobileHeader(navItems: ReturnType<typeof getNavItems>){
   return (
-    <header className="navbar fixed z-40 border-b px-2 border-base-200 bg-base-100 flex justify-between">
+    <header className="navbar fixed z-40 border-b border-base-200 bg-base-100 flex justify-between">
       <div>
         <h1 className="text-xl font-bold">
           <NavLink to="/">健常者エミュレータ事例集</NavLink>
         </h1>
       </div>
-      <div>
+      <div className="flex flex-row">
         <div className="tooltip tooltip-bottom" data-tip="検索する">
           <button className="btn btn-ghost" onClick={() => {
             const searchModal = document?.getElementById('search-modal') as HTMLDialogElement;

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -13,15 +13,13 @@ import LoginIcon from "~/components/icons/LoginIcon";
 import TopIcon from "~/components/icons/TopIcon";
 import ThumbsUpIcon from "~/components/icons/ThumbsUpIcon";
 import { useUser, SignOutButton } from "@clerk/remix";
-import { MdOutlinePostAdd, MdSearch, MdMenu } from "react-icons/md";
+import { MdOutlinePostAdd } from "react-icons/md";
 import { useCallback, useEffect, useRef, useState } from "react";
 import MenuIcon from "~/components/icons/MenuIcon";
 
 function getNavItems(isSignedIn: boolean){
   const items = [
-    { to: "/", icon: HomeIcon, text: "トップ" },
     { to: "/random", icon: RandomIcon, text: "ランダム" },
-    { to: "/post", icon: PostIcon, text: "投稿する" },
     { to: "/search", icon: SearchIcon, text: "検索する" },
     { to: "/support", text: "サポートする", icon: DonationIcon },
     { to: "/readme", text: "サイト説明", icon: GuidelineIcon },

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -128,10 +128,10 @@ function renderMobileHeader(navItems: ReturnType<typeof getNavItems>){
             >
               ✕
             </button>
-            <div className="mt-2">
+            <div className="mt-3 ml-2">
               <ThemeSwitcher />
             </div>
-            <ul className="p-4 w-50 text-base-content min-h-screen py-24 flex flex-col">
+            <ul className="p-4 w-50 text-base-content min-h-screen py-1 flex flex-col">
               {navItems.map((item) => (
                 <li key={item.to} className="justify-center">
                   {item.to === "/logout" ? (

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -161,7 +161,7 @@ export default function Component() {
         </div>
       </main>
       {/* md以下の画面サイズ向けメニュー */}
-      <div className="md:hidden tooltip tooltip-top fixed bottom-10 right-10" data-tip="投稿する">
+      <div className="tooltip tooltip-top fixed bottom-10 right-10" data-tip="投稿する">
         <NavLink to="/post">
           <button className="btn btn-primary btn-circle" type="button">
             <MdOutlinePostAdd className="text-4xl" />

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -144,17 +144,22 @@ function renderMobileHeader(navItems: ReturnType<typeof getNavItems>){
                 {navItems.map((item) => (
                   <li key={item.to} className="justify-center">
                     {item.to === "/logout" ? (
-                      <button onClick={() => {
-                        document.getElementById('drawer-toggle')?.click();
-                      }}
-                      className="flex gap-x-3 my-3 hover:bg-base-200 rounded-lg p-2"
-                      type="button"
-                      >
-                        <LogoutIcon/>
-                        <SignOutButton redirectUrl="/">
-                          {"ログアウト"}
-                        </SignOutButton>
-                      </button>
+                      <div
+                        onClick={() => {
+                          document.getElementById('drawer-toggle')?.click();
+                          }}
+                          className="flex gap-x-3 my-3 hover:bg-base-200 rounded-lg p-2 cursor-pointer"
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter" || e.key === " ") {
+                              document.getElementById('drawer-toggle')?.click();
+                            }
+                          }}
+                        > 
+                          <LogoutIcon/>
+                          <SignOutButton redirectUrl="/">
+                            ログアウト
+                          </SignOutButton>
+                        </div>
                     ) : (
                       <NavLink to={item.to} onClick={() => {
                         document.getElementById('drawer-toggle')?.click();

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -192,7 +192,7 @@ export default function Component() {
       <div className="block md:hidden">
         {renderMobileHeader(navItems, handleSearchModalOpen)}
       </div>
-      <dialog id="search-modal" className={`modal ${isSearchModalOpen ? "modal-open" : ""} -top-1/4`}>
+      <dialog id="search-modal" className={`modal ${isSearchModalOpen ? "modal-open" : ""}`}>
       <div className="modal-box">
         <div className="mt-6">
           <Form method="post" action="/search" className="flex flex-row" onSubmit={() => {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,3 +4,6 @@ Disallow: /wp-json/
 Disallow: /archives/tag/
 Disallow: /archives/*/feed
 Disallow: /wp-login.php
+Disallow: /archives/edit/
+Disallow: /tags/
+Disallow: /tag/

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -43,19 +43,18 @@ export default {
     themes: [
       {
         light: {
-          // eslint-disable-next-line @typescript-eslint/no-var-requires
-          ...require("daisyui/src/theming/themes")["light"],
+          ...require("daisyui/src/theming/themes").light,
           primary: "#99D9EA",
           secondary: "#264AF4",
           tertiary: "#00118F",
           info: "#00118F",
-          error: "#B91C1C"
+          error: "#B91C1C",
+          "base-100": "#f5f5f5",
         },
       },
       {
         dark: {
-          // eslint-disable-next-line @typescript-eslint/no-var-requires
-          ...require("daisyui/src/theming/themes")["dark"],
+          ...require("daisyui/src/theming/themes").dark,
           primary: "#99D9EA",
           secondary: "#264AF4",
           tertiary: "#00118F",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -50,6 +50,8 @@ export default {
           info: "#00118F",
           error: "#B91C1C",
           "base-100": "#f5f5f5",
+          "base-200": "#e5e5e5",
+          "base-300": "#d4d4d4",
         },
       },
       {


### PR DESCRIPTION
# 要約
- スマートフォン・PC両方のレイアウトに対して変更を加えた

## 共通変更点
- 投稿カードの表示を変更した
  - タイトルを太文字にして、タイトル表示が目立つようにした
  - アイコンをほかのアイコンと揃え、見た目がそろうようにした
- 投稿を促進するため、投稿ページにリンクされたフローティングアクションボタンを追加した
- 検索を利用しやすくするため、検索のためのモーダルウィンドウ、およびモーダルウィンドウの起動ボタンを追加した
- ライトモードのbase-100, 200, 300のカラーを変更した
- トップページのレイアウト崩れを治した
- テーマスイッチャーの見た目を変更し、変更中のフィードバック表示をした

## スマートフォン表示変更点
- ボトムナビゲーションを廃止した
- ドロワーメニューを導入した

## PC向け表示変更点
- サイドバーナビゲーションを廃止した
- メニューはヘッダーに統一した
- トップページを3列グリッド表示にした

# 他
- robots.txtでクロールしてほしくないページを追加した
- Biomeでワーニングが出ていたのを治した
- InvalidなHTML Nestingを治した