### PR TITLE
Fix: Update comment vote calculation program

### DIFF
--- a/app/modules/db.server.ts
+++ b/app/modules/db.server.ts
@@ -138,7 +138,7 @@ async function getCommentsByPostId(postId: number): Promise<CommentData[]> {
 
     const commentsWithVoteCount = comments.map((comment) => {
         const likesCount = voteCount.find((vote) => vote.commentId === comment.commentId && vote.voteType === 1)?._count.commentVoteId || 0;
-        const dislikesCount = voteCount.find((vote) => vote.commentId === comment.commentId && vote.voteType === 0)?._count.commentVoteId || 0;
+        const dislikesCount = voteCount.find((vote) => vote.commentId === comment.commentId && vote.voteType === -1)?._count.commentVoteId || 0;
         return {
             ...comment,
             likesCount,


### PR DESCRIPTION
コメントに対する「よくないね」の動作は`voteType == -1`の場合に判定されるが、ロジックを凝集させたときに謝って`voteType==0`の場合で判定していた。
そのため、正確にコメントに対するよくないねの数が集計できていなかった。