### PR TITLE
IPアドレス取得処理をCF-Connecting-IPに対応する

### DIFF
--- a/app/modules/security.server.ts
+++ b/app/modules/security.server.ts
@@ -1,4 +1,4 @@
-import { data } from "@remix-run/node";
+import { getClientIPAddress } from "remix-utils/get-client-ip-address";
 
 export async function validateRequest(token: string, origin: string) {
 
@@ -27,4 +27,10 @@ export async function getTurnStileSiteKey() {
     throw new Error("CF_TURNSTILE_SITEKEY is not set");
   }
   return key;
+}
+
+
+export async function getHashedUserIPAddress(request: Request){
+  const ipAddress = getClientIPAddress(request) || "";
+  return ipAddress;
 }

--- a/app/modules/security.server.ts
+++ b/app/modules/security.server.ts
@@ -1,5 +1,3 @@
-import { getClientIPAddress } from "remix-utils/get-client-ip-address";
-
 export async function validateRequest(token: string, origin: string) {
 
   const formData = new FormData();
@@ -31,6 +29,10 @@ export async function getTurnStileSiteKey() {
 
 
 export async function getHashedUserIPAddress(request: Request){
-  const ipAddress = getClientIPAddress(request) || "";
+  const headers = request.headers;
+  console.log("headers", headers);
+  const ipAddressFromXForwardedFor = headers.get("X-Forwarded-For");
+  const ipAddressFromCFConnectingIp = headers.get("CF-Connecting-IP");
+  const ipAddress = ipAddressFromCFConnectingIp || ipAddressFromXForwardedFor || "";
   return ipAddress;
 }

--- a/app/routes/_layout.post.tsx
+++ b/app/routes/_layout.post.tsx
@@ -21,7 +21,7 @@ import { commonMetaFunction } from "~/utils/commonMetafunction";
 import { toast, Toaster } from "react-hot-toast";
 import { createPostFormSchema } from "~/schemas/post.schema";
 import { Turnstile } from "@marsidev/react-turnstile";
-import { getTurnStileSiteKey, validateRequest } from "~/modules/security.server";
+import { getHashedUserIPAddress, getTurnStileSiteKey, validateRequest } from "~/modules/security.server";
 
 
 export async function loader () {
@@ -638,10 +638,7 @@ export async function action({ request }:ActionFunctionArgs){
   }
 }
 
-async function getHashedUserIPAddress(request: Request){
-  const ipAddress = getClientIPAddress(request) || "";
-  return ipAddress;
-}
+
 
 async function Wikify(postData: z.infer<ReturnType<typeof createPostFormSchema>>, postFormSchema: ReturnType<typeof createPostFormSchema>){
   // バリデーションを実施


### PR DESCRIPTION
# 変更概要
- いままでの取得方式だと、CloudflareのIPアドレスを取得してしまい、IPバンの用途を満たさなかった
- headerのCF-Connecting-IPを利用してIPアドレスを取得するように変更する