### PR TITLE
コメント自体をシェアできるようにする

### DIFF
--- a/app/components/CommentCard.tsx
+++ b/app/components/CommentCard.tsx
@@ -9,6 +9,8 @@ import { z } from "zod";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import type { CommentFormInputs } from "./CommentInputBox";
+import { Share } from 'lucide-react';
+
 
 const commentVoteSchema = z.object({
   commentId: z.number(),
@@ -92,14 +94,31 @@ export default function CommentCard({
     onCommentVote(getValues());
   };
 
+  const invokeShareAPI = async (currentURL: string, postTitle: string) => {
+    try {
+        await navigator.share({ url: currentURL, title: postTitle });
+    } catch (error) {
+        console.error("シェアAPIが使えませんでした", error);
+    }
+}
+
   return (
     <div className="bg-base-100 p-4 mb-4" style={{ marginLeft }}>
       <div className="flex items-center">
         <p className="text-green-700 font-bold mr-1">{commentAuthor}</p>
         <div className="pr-0.5">
-        <ClockIcon  />
+          <ClockIcon  />
         </div>
         <RelativeDate timestamp={commentDateGmt} />
+        <div>
+          <button
+            type="button"
+            className="btn btn-circle btn-sm btn-ghost"
+            onClick={() => invokeShareAPI(`${window.location.href.split("#")[0]}#comment-${commentId}`, "健常者エミュレータ事例集")}
+          >
+            <Share className="fill-none stroke-current w-4 h-4" />
+          </button>
+        </div>
       </div>
       <p className="whitespace-pre-wrap break-words">{commentContent}</p>
       <div className="flex items-center mt-4">　　　　　　

--- a/app/routes/_layout.archives.$postId.tsx
+++ b/app/routes/_layout.archives.$postId.tsx
@@ -136,7 +136,7 @@ export default function Component() {
     return data.comments
       .filter((comment) => comment.commentParent === parentId)
       .map((comment) => (
-        <div key={comment.commentId}>
+        <div key={comment.commentId} id={`comment-${comment.commentId}`}>
           <CommentCard
             commentId={comment.commentId}
             postId={POSTID}

--- a/app/routes/_layout.archives.$postId.tsx
+++ b/app/routes/_layout.archives.$postId.tsx
@@ -1,6 +1,7 @@
 import { json } from "@remix-run/node";
 import { useLoaderData, NavLink,useFetcher } from "@remix-run/react";
-import type { LoaderFunctionArgs, ActionFunctionArgs, MetaFunction } from "@remix-run/node";
+import type { LoaderFunctionArgs, ActionFunctionArgs } from "@remix-run/node";
+import type { MetaFunction } from "@remix-run/react";
 import parser from "html-react-parser";
 import { Turnstile } from "@marsidev/react-turnstile";
 import { prisma, ArchiveDataEntry } from "~/modules/db.server";
@@ -488,29 +489,18 @@ async function handleSubmitComment(formData: FormData, postId: number, userIpHas
 }
 
 
-export const meta: MetaFunction<typeof loader> = ({ data, location }) => {
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
   if (!data){
     return [{ title: "Loading..." }];
   }
   const title = data.data.postTitle;
   const postDescription = data.data.tags.map((tag) => tag.tagName).join(", ");
-  
-  const hash = location.hash;
-  const commentId = hash.replace("#comment-", "");
-  let commentDescription = "";
-  if (commentId) {
-    const comment = data.data.comments.find((comment) => comment.commentId === Number(commentId));
-    if (comment) {
-      commentDescription = comment.commentContent;
-    }
-  }
-
   const url = `https://healthy-person-emulator.org/archives/${data.data.postId}`;
   const image = data.data.ogpImageUrl;
 
   const commonMeta = commonMetaFunction({
     title,
-    description: commentDescription ?? postDescription,
+    description: postDescription,
     url,
     image
   });

--- a/app/routes/_layout.archives.$postId.tsx
+++ b/app/routes/_layout.archives.$postId.tsx
@@ -488,18 +488,29 @@ async function handleSubmitComment(formData: FormData, postId: number, userIpHas
 }
 
 
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
+export const meta: MetaFunction<typeof loader> = ({ data, location }) => {
   if (!data){
     return [{ title: "Loading..." }];
   }
   const title = data.data.postTitle;
-  const description = data.data.tags.map((tag) => tag.tagName).join(", ");
+  const postDescription = data.data.tags.map((tag) => tag.tagName).join(", ");
+  
+  const hash = location.hash;
+  const commentId = hash.replace("#comment-", "");
+  let commentDescription = "";
+  if (commentId) {
+    const comment = data.data.comments.find((comment) => comment.commentId === Number(commentId));
+    if (comment) {
+      commentDescription = comment.commentContent;
+    }
+  }
+
   const url = `https://healthy-person-emulator.org/archives/${data.data.postId}`;
   const image = data.data.ogpImageUrl;
 
   const commonMeta = commonMetaFunction({
     title,
-    description,
+    description: commentDescription ?? postDescription,
     url,
     image
   });

--- a/app/routes/_layout.archives.$postId.tsx
+++ b/app/routes/_layout.archives.$postId.tsx
@@ -175,6 +175,18 @@ export default function Component() {
     }
   }, [fetcher.data, isValificationFailed]);
 
+  useEffect(() => {
+    const hash = window.location.hash;
+    if (hash) {
+      const commentId = hash.replace("#comment-", "");
+      const commentElement = document.getElementById(`comment-${commentId}`);
+      if (commentElement) {
+        commentElement.scrollIntoView({ behavior: "smooth" });
+      }
+    }
+  }, []);
+  // コメントIDをURLに含めると、そのコメントにスクロールするための機能
+  // http://localhost:3000/archives/46783#comment-32944
 
   return (
     <>


### PR DESCRIPTION
# 変更概要
- コメントに対して共有ボタンを追加し、Share API経由でシェアできるようにした
- 記事表示ページを改修し、location.hashにコメントIDが含まれている場合は当該コメントまで自動スクロールするようにした