### PR TITLE
【CLS対策】投稿表示カードのimgタグの`width`と`height`属性の値を固定する

### DIFF
--- a/app/components/PostCard.tsx
+++ b/app/components/PostCard.tsx
@@ -34,17 +34,6 @@ export default function PostCard({
     countComments,
     identifier,
 }: PostCardProps) {
-
-    tagNames.sort((a, b) => {
-        if (a > b) {
-            return 1;
-        }
-        if (a < b) {
-            return -1;
-        }
-        return 0;
-    });
-
     const displayedTags = tagNames.slice(0, 5);
     const hiddenTagsCount = tagNames.length - displayedTags.length;
 

--- a/app/components/PostCard.tsx
+++ b/app/components/PostCard.tsx
@@ -63,7 +63,14 @@ export default function PostCard({
                     </div>
                 </div>
                 <NavLink to={`/archives/${postId}`} className="hover:underline hover:underline-offset-4">
-                    <img src={`https://healthy-person-emulator-public-assets.s3.ap-northeast-1.amazonaws.com/${postId}.jpg`} alt={postTitle} className="w-full object-cover" loading="lazy"/>
+                    <img
+                        src={`https://healthy-person-emulator-public-assets.s3.ap-northeast-1.amazonaws.com/${postId}.jpg`}
+                        alt={postTitle}
+                        className="w-full object-cover"
+                        loading="lazy"
+                        width={1200}
+                        height={630}
+                    />
                     <div className="mt-1 mb-2">
                         <p className="text-xl font-bold">{postTitle}</p>
                     </div>

--- a/app/modules/db.server.ts
+++ b/app/modules/db.server.ts
@@ -311,10 +311,15 @@ export async function getRecentPosts(): Promise<PostCardData[]>{
                             tagId: true,
                         }
                     }
+                },
+                orderBy: {
+                    dimTag: {
+                        tagName: "asc",
                     }
                 }
             }
-    }).then((posts) => {
+        }
+        }).then((posts) => {
         return posts.map((post) => {
             return {
                 ...post,
@@ -381,6 +386,11 @@ export async function getRecentVotedPosts(): Promise<PostCardData[]>{
                             tagId: true,
                         }
                     }
+                },
+                orderBy: {
+                    dimTag: {
+                        tagName: "asc",
+                    }
                 }
             }
         }
@@ -416,6 +426,11 @@ export async function getRecentPostsByTagId(tagId: number): Promise<PostCardData
                                     tagName: true,
                                     tagId: true,
                                 }
+                            }
+                        },
+                        orderBy: {
+                            dimTag: {
+                                tagName: "asc",
                             }
                         }
                     }
@@ -528,6 +543,11 @@ export async function getRandomPosts(): Promise<PostCardData[]> {
                         },
                     },
                 },
+                orderBy: {
+                    dimTag: {
+                        tagName: "asc",
+                    }
+                }
             },
         },
         orderBy: { uuid : "asc"},


### PR DESCRIPTION
# 変更概要
- OG画像作成プログラムを改修し、縦横のピクセル幅を固定する仕様にした
- CLS対策のため、imgのwidthとheight属性を固定する。