### PR TITLE
【CLS対策】フォントファイルをPreloadしてフォールバックによるレイアウトシフトを防ぐ

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -20,7 +20,14 @@ import { useCallback, useEffect } from "react";
 import { FaSpinner } from "react-icons/fa";
 
 export const links: LinksFunction = () => [
-  { rel: "stylesheet", href: stylesheet }
+  { rel: "stylesheet", href: stylesheet },
+  { 
+    rel: "preload",
+    href: "/fonts/NotoSansJP-Medium.ttf",
+    as: "font",
+    type: "font/ttf",
+    crossOrigin: "anonymous"
+  }
 ];
 
 export const loader: LoaderFunction = (args) => rootAuthLoader(args);

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -20,13 +20,7 @@ import { useCallback, useEffect } from "react";
 import { FaSpinner } from "react-icons/fa";
 
 export const links: LinksFunction = () => [
-  { rel: "stylesheet", href: stylesheet },
-  { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
-  { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossOrigin: 'anonymous' },
-  {
-    rel: 'stylesheet',
-    href: 'https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100..900&family=Ubuntu:ital,wght@0,300;0,400;0,500;0,700;1,300;1,400;1,500;1,700&display=swap',
-  },
+  { rel: "stylesheet", href: stylesheet }
 ];
 
 export const loader: LoaderFunction = (args) => rootAuthLoader(args);

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -32,7 +32,6 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
         <meta property="og:site_name" content="健常者エミュレータ事例集"/>
-        <meta name="google-adsense-account" content="ca-pub-8395466399694773"/>
         <Meta />
         <Links />
       </head>

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -1,13 +1,15 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 @font-face {
   font-family: 'Noto Sans JP';
   src: url('/fonts/NotoSansJP-Medium.ttf') format('truetype');
   font-weight: 400;
   font-display: swap;
 }
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+
 
 h1 {
   @apply text-4xl font-bold;

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -2,7 +2,7 @@
   font-family: 'Noto Sans JP';
   src: url('/fonts/NotoSansJP-Medium.ttf') format('truetype');
   font-weight: 400;
-  font-display: swap;
+  font-display: optional;
 }
 
 @tailwind base;

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -1,8 +1,13 @@
-@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100..900&family=Ubuntu:ital,wght@0,300;0,400;0,500;0,700;1,300;1,400;1,500;1,700&display=swap');
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@font-face {
+  font-family: 'Noto Sans JP';
+  src: url('/fonts/NotoSansJP-Medium.ttf') format('truetype');
+  font-weight: 400;
+  font-display: swap;
+}
 
 h1 {
   @apply text-4xl font-bold;


### PR DESCRIPTION
# 変更概要
- フォントファイルをGoogle Fontsからローカルに移行した
- フォントファイルの読み込みをpreloadにして、フォールバックによるレイアウトシフトを防いだ
- font-dispaly: optionalを設定し、100ミリ秒以内にフォントが読みこまれない場合は自動的にデフォルトフォントを利用するようにした