### PR TITLE
ダークモード・ライトモード間の切り替えによるちらつきを抑制する

### DIFF
--- a/app/components/ThemeSwitcher.tsx
+++ b/app/components/ThemeSwitcher.tsx
@@ -1,32 +1,21 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Sun, Moon, Loader } from "lucide-react";
+import { useAtomValue, useSetAtom } from "jotai";
+import { getThemeAtom, toggleThemeAtom } from "../stores/theme";
 
 export default function ThemeSwitcher() {
-  const [nowTheme, setNowTheme] = useState<string>();
+  const nowTheme = useAtomValue(getThemeAtom);
+  const toggleTheme = useSetAtom(toggleThemeAtom);
   const [isChanging, setIsChanging] = useState(false);
-
-  useEffect(() => {
-    if (window.localStorage.getItem("theme") === null) {
-      const initialTheme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-      window.localStorage.setItem("theme", initialTheme);
-    }
-    const theme = window.localStorage.getItem("theme") || "dark";
-    setNowTheme(theme);
-    document.querySelector("html")?.setAttribute("data-theme", theme);
-  }, []);
-
-  const toggleTheme = () => {
+  const handleToggleTheme = () => {
     setIsChanging(true);
-    const newTheme = nowTheme === "dark" ? "light" : "dark";
-    window.localStorage.setItem("theme", newTheme);
-    setNowTheme(newTheme);
-    document.querySelector("html")?.setAttribute("data-theme", newTheme);
+    toggleTheme();
     setTimeout(() => setIsChanging(false), 500);
   };
 
   return (
     <button
-      onClick={toggleTheme}
+      onClick={handleToggleTheme}
       type="button"
       className="btn btn-ghost h-9 w-9 p-0"
     >

--- a/app/components/ThemeSwitcher.tsx
+++ b/app/components/ThemeSwitcher.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Sun, Moon, Loader } from "lucide-react";
 import { useAtomValue, useSetAtom } from "jotai";
 import { getThemeAtom, toggleThemeAtom } from "../stores/theme";
@@ -7,11 +7,20 @@ export default function ThemeSwitcher() {
   const nowTheme = useAtomValue(getThemeAtom);
   const toggleTheme = useSetAtom(toggleThemeAtom);
   const [isChanging, setIsChanging] = useState(false);
+
   const handleToggleTheme = () => {
     setIsChanging(true);
+    document.documentElement.classList.add('theme-transition');
     toggleTheme();
-    setTimeout(() => setIsChanging(false), 500);
+    setTimeout(() => {
+      setIsChanging(false);
+      document.documentElement.classList.remove('theme-transition');
+    }, 500);
   };
+
+  useEffect(() => {
+    document.documentElement.classList.remove('theme-transition');
+  }, []);
 
   return (
     <button

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -36,6 +36,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ja" className="font-noto-sans">
       <head>
+        <script src="/nofrash.js" async defer />
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
         <meta property="og:site_name" content="健常者エミュレータ事例集"/>

--- a/app/stores/theme.ts
+++ b/app/stores/theme.ts
@@ -1,0 +1,12 @@
+import { atomWithStorage } from "jotai/utils";
+import { atom } from "jotai";
+
+export const themeAtom = atomWithStorage("theme", "light");
+
+export const getThemeAtom = atom((get) => get(themeAtom));
+
+export const toggleThemeAtom = atom(null, (get, set) => {
+    const newTheme = get(themeAtom) === "light" ? "dark" : "light";
+    set(themeAtom, newTheme);
+    document.querySelector("html")?.setAttribute("data-theme", newTheme);
+});

--- a/app/stores/theme.ts
+++ b/app/stores/theme.ts
@@ -6,7 +6,8 @@ export const themeAtom = atomWithStorage("theme", "light");
 export const getThemeAtom = atom((get) => get(themeAtom));
 
 export const toggleThemeAtom = atom(null, (get, set) => {
-    const newTheme = get(themeAtom) === "light" ? "dark" : "light";
+    const newTheme = get(themeAtom) === 'light' ? 'dark' : 'light';
     set(themeAtom, newTheme);
     document.querySelector("html")?.setAttribute("data-theme", newTheme);
 });
+

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -112,3 +112,11 @@ svg {
               transform 300ms ease-in-out,
               max-height 300ms ease-in-out;
 }
+
+.theme-transition {
+  transition: background-color 0.5s ease;
+}
+
+.theme-transition * {
+  transition: background-color 0.5s ease, border-color 0.5s ease;
+}

--- a/public/nofrash.js
+++ b/public/nofrash.js
@@ -24,4 +24,15 @@
         setClassOnDocumentBody(classNameLight)
       }
     }
+    // メディアクエリのデフォルトを設定
+    if (!localStorageExists) {
+      const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+      if (mediaQuery.matches) {
+        setClassOnDocumentBody(classNameDark)
+        localStorage.setItem(storageKey, JSON.stringify(classNameDark))
+      } else {
+        setClassOnDocumentBody(classNameLight)
+        localStorage.setItem(storageKey, JSON.stringify(classNameLight))
+      }
+    }
   })()

--- a/public/nofrash.js
+++ b/public/nofrash.js
@@ -1,0 +1,27 @@
+// This will help to prevent a flash according to theme change.
+
+;(() => {
+    const storageKey = 'theme'
+    const classNameDark = '"dark"'
+    const classNameLight = '"light"'
+  
+    function setClassOnDocumentBody(className) {
+      const html = document.getElementsByTagName('html')[0]
+      html.setAttribute('data-theme', className.slice(1, -1))
+    }
+  
+    let localStorageTheme = null
+    try {
+      localStorageTheme = localStorage.getItem(storageKey)
+    } catch (err) {}
+    const localStorageExists = localStorageTheme !== null
+  
+    if (localStorageExists) {
+      if (localStorageTheme === classNameDark) {
+        setClassOnDocumentBody(classNameDark)
+      }
+      if (localStorageTheme === classNameLight) {
+        setClassOnDocumentBody(classNameLight)
+      }
+    }
+  })()

--- a/public/nofrash.js
+++ b/public/nofrash.js
@@ -2,17 +2,17 @@
 
 ;(() => {
     const storageKey = 'theme'
-    const classNameDark = '"dark"'
-    const classNameLight = '"light"'
+    const classNameDark = 'dark'
+    const classNameLight = 'light'
   
     function setClassOnDocumentBody(className) {
       const html = document.getElementsByTagName('html')[0]
-      html.setAttribute('data-theme', className.slice(1, -1))
+      html.setAttribute('data-theme', className)
     }
   
     let localStorageTheme = null
     try {
-      localStorageTheme = localStorage.getItem(storageKey)
+      localStorageTheme = JSON.parse(localStorage.getItem(storageKey))
     } catch (err) {}
     const localStorageExists = localStorageTheme !== null
   


### PR DESCRIPTION
# 変更概要
- ThemeSwicherをjotaiを利用して書き換えた
- localStorage内部のThemeの値とテーマの整合性を取るために発生していたちらつきを抑制する