### PR TITLE
Fix: Remove `async` and `defer` attribute to nofrash.js

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -36,7 +36,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ja" className="font-noto-sans">
       <head>
-        <script src="/nofrash.js" async defer />
+        <script src="/nofrash.js"/>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
         <meta property="og:site_name" content="健常者エミュレータ事例集"/>


### PR DESCRIPTION
# 変更概要
- 本番環境でnofrash.jsの読み込み順を見てみたところ、HTMLパースの完了後に読みこまれていた
- それでは意味がないので直す