### PR TITLE
【ちらつき対策】Themeのlocalstorageとの同期を削除

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -43,7 +43,6 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Links />
       </head>
       <body>
-        <script src="/nofrash.js"/>
         <PageTransitionProgressBar />
         {children}
         <ScrollRestoration />

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -34,7 +34,7 @@ export const loader: LoaderFunction = (args) => rootAuthLoader(args);
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="ja" className="font-noto-sans">
+    <html lang="ja" className="font-noto-sans" data-theme="light">
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />

--- a/app/stores/theme.ts
+++ b/app/stores/theme.ts
@@ -1,7 +1,6 @@
-import { atomWithStorage } from "jotai/utils";
 import { atom } from "jotai";
 
-export const themeAtom = atomWithStorage("theme", "light");
+export const themeAtom = atom("light");
 
 export const getThemeAtom = atom((get) => get(themeAtom));
 


### PR DESCRIPTION
# 変更概要
- SSRでダークモードに真面目に対応させるのは難易度が高い
- localStorageとの同期機能を削除し、状態として保持しないようにした
- ちらつきは抑えられる