### PR TITLE
投稿ページの微修正

### DIFF
--- a/app/components/ShareButtons.tsx
+++ b/app/components/ShareButtons.tsx
@@ -3,6 +3,7 @@ import MastodonLogo from "~/src/assets/mastodon_logo.svg"
 import MisskeyLogo from "~/src/assets/misskey_icon.png"
 import CopyToClipBoard from "./icons/CopyToClipboard";
 import ShareButtonAPI from "./icons/ShareButtonAPI";
+import toast from "react-hot-toast";
 
 interface ShareButtonsProps {
     currentURL: string;
@@ -14,7 +15,12 @@ export default function ShareButtons({ currentURL, postTitle }: ShareButtonsProp
     const url = new URL(currentURL);
     const hatenaBlogUrl = url.hostname + url.pathname;
     const copy = async (currentURL: string) => {
-        await navigator.clipboard.writeText(currentURL);
+        try {
+            await navigator.clipboard.writeText(currentURL);
+            toast.success("クリップボードにコピーしました。");
+        } catch (error) {
+            toast.error("クリップボードにコピーできませんでした。");
+        }
     }
 
     const invokeShareAPI = async (currentURL: string, postTitle: string) => {

--- a/app/routes/_layout.post.tsx
+++ b/app/routes/_layout.post.tsx
@@ -228,7 +228,12 @@ export default function App() {
   }, [firstSubmitFetcher.state]);
 
   const handleCopy = () => {
-    navigator.clipboard.writeText(firstSubmitFetcher?.data?.data?.MarkdownResult);
+    try {
+      navigator.clipboard.writeText(firstSubmitFetcher?.data?.data?.MarkdownResult);
+      toast.success("クリップボードにコピーしました。");
+    } catch (error) {
+      toast.error("クリップボードにコピーできませんでした。");
+    }
   }
 
   const secondSubmitFetcher = useFetcher();

--- a/app/routes/_layout.post.tsx
+++ b/app/routes/_layout.post.tsx
@@ -219,10 +219,10 @@ export default function App() {
     if (firstSubmitFetcher.state === "submitting") {
       toast.loading("プレビューを取得しています");
     }
-    if (firstSubmitFetcher.state === "submitting" || firstSubmitFetcher.state === "loading") {
+    if (firstSubmitFetcher.state === "submitting") {
       setIsFirstSubmitButtonOpen(false);
     }
-    if (firstSubmitFetcher.state === "idle") {
+    if (firstSubmitFetcher.state === "loading") {
       setIsFirstSubmitButtonOpen(true);
       toast.dismiss();// ローディング中のトーストを消す
     }

--- a/app/routes/_layout.post.tsx
+++ b/app/routes/_layout.post.tsx
@@ -271,7 +271,7 @@ export default function App() {
       setTimeout(() => {
         const postId = response?.data?.postId;
         navigate(`/archives/${postId}`, {viewTransition: true});
-      }, 1000);
+      }, 2000);
     }
     return () => {
       toast.dismiss("post-success-toast");

--- a/app/routes/_layout.post.tsx
+++ b/app/routes/_layout.post.tsx
@@ -6,15 +6,14 @@ import {
   useFieldArray,
 } from "react-hook-form";
 import { useEffect, useState } from "react";
+// biome-ignore lint/style/useImportType: <explanation>
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
   Form,
   json,
-  useActionData,
   useFetcher,
   useLoaderData,
-  useLocation,
   useNavigate,
 } from "@remix-run/react";
 import UserExplanation from "~/components/SubmitFormComponents/UserExplanation";
@@ -55,7 +54,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 }
 
 export default function App() {
-  const { tags, stopWords, isValid, turnStileSiteKey } = useLoaderData<typeof loader>();
+  const { tags, stopWords, turnStileSiteKey } = useLoaderData<typeof loader>();
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [createdTags, setCreatedTags] = useState<string[]>([]);
 
@@ -92,7 +91,6 @@ export default function App() {
   type Inputs = z.infer<typeof postFormSchema>;
 
   const getStoredValues = (): Inputs => {
-    // biome-ignore lint/suspicious/noThenProperty: <explanation>
     if (typeof window === "undefined")
       return {
         title: [],
@@ -104,6 +102,7 @@ export default function App() {
           where: "",
           why: "",
           how: "",
+          // biome-ignore lint/suspicious/noThenProperty: <explanation>
           then: "",
         },
         reflection: [],
@@ -113,7 +112,6 @@ export default function App() {
         createdTags: [],
       };
     const stored = window.localStorage.getItem(formId);
-    // biome-ignore lint/suspicious/noThenProperty: <explanation>
     return stored
       ? JSON.parse(stored)
       : {
@@ -126,6 +124,7 @@ export default function App() {
             where: "",
             why: "",
             how: "",
+            // biome-ignore lint/suspicious/noThenProperty: <explanation>
             then: "",
           },
           reflection: [],
@@ -164,10 +163,11 @@ export default function App() {
   };
 
   useEffect(() => {
-    if (turnstileFetcher.data?.success === false) {
+    const response = turnstileFetcher.data as { success: boolean };
+    if (response?.success === false) {
       toast.error("リクエスト検証に失敗しました。時間をおいて再度お試しください。");
     }
-    if (turnstileFetcher.data?.success === true) {
+    if (response?.success === true) {
       setIsFirstSubmitButtonOpen(true);
     }
   }, [turnstileFetcher.data]);
@@ -206,10 +206,11 @@ export default function App() {
   const [isFirstSubmitButtonOpen, setIsFirstSubmitButtonOpen] = useState(false);
 
   useEffect(() => {
-    if ((firstSubmitFetcher.data as { success: boolean })?.success) {
+    const response = firstSubmitFetcher.data as { success: boolean };
+    if (response?.success) {
       setIsPreviewModalOpen(true);
     }
-    if ((firstSubmitFetcher.data as { success: boolean })?.success === false) {
+    if (response?.success === false) {
       toast.error("プレビューを取得できませんでした。時間をおいて再度試してください。");
     }
   }, [firstSubmitFetcher.data]);
@@ -228,8 +229,9 @@ export default function App() {
   }, [firstSubmitFetcher.state]);
 
   const handleCopy = () => {
+    const response = firstSubmitFetcher.data as { data: { MarkdownResult: string } };
     try {
-      navigator.clipboard.writeText(firstSubmitFetcher?.data?.data?.MarkdownResult);
+      navigator.clipboard.writeText(response?.data?.MarkdownResult);
       toast.success("クリップボードにコピーしました。");
     } catch (error) {
       toast.error("クリップボードにコピーできませんでした。");
@@ -260,13 +262,14 @@ export default function App() {
 
   const navigate = useNavigate();
   useEffect(() => {
-    if (secondSubmitFetcher.data?.success === true && secondSubmitFetcher.state === "idle") {
+    const response = secondSubmitFetcher.data as { success: boolean, data: { postId: number } };
+    if (response?.success === true && secondSubmitFetcher.state === "idle") {
       toast.success("投稿しました。リダイレクトします...", {
         icon: "🎉",
         id: "post-success-toast",
       })
       setTimeout(() => {
-        const postId = secondSubmitFetcher.data?.data?.postId;
+        const postId = response?.data?.postId;
         navigate(`/archives/${postId}`, {viewTransition: true});
       }, 1000);
     }
@@ -289,6 +292,7 @@ export default function App() {
         where: "",
         why: "",
         how: "",
+        // biome-ignore lint/suspicious/noThenProperty: <explanation>
         then: "",
       },
       reflection: [],

--- a/app/utils/itemMenu.ts
+++ b/app/utils/itemMenu.ts
@@ -1,4 +1,4 @@
-import { House, Search, HandCoins, BookText, ThumbsUp, Notebook, Shuffle, LogOut, LogIn, UserPlus } from 'lucide-react';
+import { House, Search, HandCoins, BookText, ThumbsUp, Notebook, Shuffle, LogOut, LogIn, UserPlus, FilePlus } from 'lucide-react';
 
 export function getNavItems(isSignedIn: boolean){
     return [
@@ -9,6 +9,7 @@ export function getNavItems(isSignedIn: boolean){
         { to: "/readme", text: "サイト説明", icon: BookText },
         { to: "/feed?p=1&type=unboundedLikes", text: "無期限いいね順", icon: ThumbsUp },
         { to: "/search", icon: Search, text: "検索する" },
+        { to: "/post", text: "投稿する", icon: FilePlus },
 
         ...(isSignedIn
           ? [{ to: "/logout", text: "ログアウト", icon: LogOut }]


### PR DESCRIPTION
# 変更概要
- 投稿ページにおいて、クリップボードにMarkdown形式でコピーした際にtoastを表示するようにした
- 記事ページにおいて、クリップボードにURLをコピーした際にtoastを表示するようにした
- メニューバーに投稿フォームへの導線を追加した
- post.tsx内部のエラーを抑制した
- FirstSubmitButtonのDisabledの制御を治した
- Experimental機能として、投稿ページにおいてクリップボードでURLをコピーした際にvibrationを発生させるようにした