### PR TITLE
編集導線をtoastでわかりやすくする & モバイル版のヘッダーが改行されていたのを修正 & viewTransitionAPIを使いまくる

### DIFF
--- a/app/components/CommonNavLink.tsx
+++ b/app/components/CommonNavLink.tsx
@@ -1,0 +1,13 @@
+import { NavLink } from "@remix-run/react";
+
+export function CommonNavLink({ to, children, className }: { to: string, children?: React.ReactNode, className?: string }) {
+  return (
+    <NavLink
+      to={to}
+      className={`text-info underline-offset-4 hover:bg-info ${className}`}
+      viewTransition
+    >
+      {children}
+    </NavLink>
+  );
+}

--- a/app/components/CommonNavLink.tsx
+++ b/app/components/CommonNavLink.tsx
@@ -4,7 +4,7 @@ export function CommonNavLink({ to, children, className }: { to: string, childre
   return (
     <NavLink
       to={to}
-      className={`text-info underline underline-offset-4 hover:bg-base-200 rounded-md px-2 py-1 ${className}`}
+      className={`text-info underline underline-offset-4 hover:bg-base-200 rounded-md px-1 py-1 ${className}`}
       viewTransition
     >
       {children}

--- a/app/components/CommonNavLink.tsx
+++ b/app/components/CommonNavLink.tsx
@@ -4,7 +4,7 @@ export function CommonNavLink({ to, children, className }: { to: string, childre
   return (
     <NavLink
       to={to}
-      className={`text-info underline-offset-4 hover:bg-info ${className}`}
+      className={`text-info underline underline-offset-4 hover:bg-base-200 rounded-md px-2 py-1 ${className}`}
       viewTransition
     >
       {children}

--- a/app/components/PostCard.tsx
+++ b/app/components/PostCard.tsx
@@ -62,7 +62,7 @@ export default function PostCard({
                         )}
                     </div>
                 </div>
-                <NavLink to={`/archives/${postId}`} className="hover:underline hover:underline-offset-4">
+                <NavLink to={`/archives/${postId}`} className="hover:underline hover:underline-offset-4" viewTransition>
                     <img
                         src={`https://healthy-person-emulator-public-assets.s3.ap-northeast-1.amazonaws.com/${postId}.jpg`}
                         alt={postTitle}

--- a/app/components/TagCard.tsx
+++ b/app/components/TagCard.tsx
@@ -9,7 +9,7 @@ export default function TagCard({
 }: TagCardProps) {
     return (
         <div className="rounded-md p-0.5 mb-0.5 badge border-none">
-            <NavLink to={`/tags/${tagName}`} className="text-xs post-tag rounded-lg bg-base-300 px-2 py-1 hover:bg-base-200">{tagName}</NavLink>
+            <NavLink to={`/tags/${tagName}`} className="text-xs post-tag rounded-lg bg-base-300 px-2 py-1 hover:bg-base-200" viewTransition>{tagName}</NavLink>
         </div>
     );
 }

--- a/app/routes/_layout.archives.$postId.tsx
+++ b/app/routes/_layout.archives.$postId.tsx
@@ -287,6 +287,7 @@ export default function Component() {
           <NavLink
             to={`/archives/edit/${POSTID}`}
             className="btn-primary rounded px-4 py-2 mx-1 my-20"
+            viewTransition
           >
             編集する
           </NavLink>

--- a/app/routes/_layout.archives.$postId.tsx
+++ b/app/routes/_layout.archives.$postId.tsx
@@ -292,7 +292,7 @@ export default function Component() {
           </NavLink>
         </div>
         <H2>関連記事</H2>
-        <div>
+        <div className="w-full px-1">
           <ul className="list-disc list-outside mb-4 ml-4">
             {data.similarPosts.map((post) => (
               <li key={post.postId} className="my-2">

--- a/app/routes/_layout.archives.$postId.tsx
+++ b/app/routes/_layout.archives.$postId.tsx
@@ -25,6 +25,7 @@ import { TurnstileModal } from "~/components/TurnstileModal";
 import toast, { Toaster } from "react-hot-toast";
 import { VoteButton } from "~/components/VoteButton";
 import { SNSLinks } from "~/components/SNSLinks";
+import { CommonNavLink } from "~/components/CommonNavLink";
 
 export const commentVoteSchema = z.object({
   commentId: z.number(),
@@ -295,12 +296,11 @@ export default function Component() {
           <ul className="list-disc list-outside mb-4 ml-4">
             {data.similarPosts.map((post) => (
               <li key={post.postId} className="my-2">
-                <NavLink
+                <CommonNavLink
                   to={`/archives/${post.postId}`}
-                  className="text-info underline underline-offset-4"
                 >
                   {post.postTitle}
-                </NavLink>
+                </CommonNavLink>
               </li>
             ))}
           </ul>

--- a/app/routes/_layout.archives.$postId.tsx
+++ b/app/routes/_layout.archives.$postId.tsx
@@ -309,22 +309,20 @@ export default function Component() {
           {data.nextPost ? (
             <div className="flex items-center mb-4 md:mb-0">
               <ArrowForwardIcon />
-              <NavLink
+              <CommonNavLink
                 to={`/archives/${data.nextPost.postId}`}
-                className="text-info underline underline-offset-4"
               >
                 {data.nextPost.postTitle}
-              </NavLink>
+              </CommonNavLink>
             </div>
           ): (<div/>)}
           {data.previousPost ? (
             <div className="flex items-center">
-              <NavLink
+              <CommonNavLink
                 to={`/archives/${data.previousPost.postId}`}
-                className="text-info underline underline-offset-4 mr-2"
               >
                 {data.previousPost.postTitle}
-              </NavLink>
+              </CommonNavLink>
               <ArrowBackIcon  />
             </div>
           ): <div/>}

--- a/app/routes/_layout.archives.edit.$postId.tsx
+++ b/app/routes/_layout.archives.edit.$postId.tsx
@@ -248,7 +248,7 @@ export default function EditPost() {
         id: "post-success-toast",
       })
       setTimeout(() => {
-        navigate(`/archives/${postId}`);
+        navigate(`/archives/${postId}`, { viewTransition: true });
       }, 2000);
     }
 

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -77,7 +77,9 @@ function renderMobileHeader(handleSearchModalOpen: (status: boolean) => void){
     <header className="navbar fixed z-40 border-b border-base-200 bg-base-100 flex justify-between p-4">
       <div>
         <h1 className="text-xl font-bold">
-          <NavLink to="/?referrer=fromHeader">健常者エミュレータ事例集</NavLink>
+        <NavLink to="/?referrer=fromHeader" className="text-[clamp(0.875rem,3vw,1.25rem)] whitespace-nowrap">
+            健常者エミュレータ事例集
+          </NavLink>
         </h1>
       </div>
       <div className="flex flex-row">

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -48,6 +48,7 @@ function renderDesktopHeader(){
                       <NavLink 
                         to={item.to} 
                         className={`flex items-center gap-2 p-2 rounded-lg hover:bg-base-300 ${isActive ? 'bg-base-200 font-bold' : ''}`}
+                        viewTransition
                       >
                         <item.icon className="w-5 h-5 stroke-current fill-none min-w-[1.25rem]" />
                         <span className="invisible w-0 group-hover:visible group-hover:w-auto 2xl:visible 2xl:w-auto whitespace-nowrap transition-all duration-300">
@@ -142,6 +143,7 @@ function renderMobileHeader(handleSearchModalOpen: (status: boolean) => void){
                         document.getElementById('drawer-toggle')?.click();
                       }}
                       className="flex gap-x-3 my-3 hover:bg-base-200 rounded-lg p-2"
+                      viewTransition
                       >
                         <item.icon className="w-5 h-5 stroke-current fill-none" />
                         {item.text}
@@ -230,7 +232,7 @@ export default function Component() {
         </div>
       </main>
       <div className="tooltip tooltip-top fixed bottom-10 right-10" data-tip="投稿する">
-        <NavLink to="/post">
+        <NavLink to="/post" viewTransition>
           <button className={`btn btn-primary btn-circle btn-lg ${isInPostPage ? "hidden inert" : ""}`} type="button">
             <PostIcon />
           </button>


### PR DESCRIPTION
# 変更概要
- 編集導線をtoastでわかりやすくした
- モバイル版のヘッダーが改行されていたのでclampで直した
- viewTransitionAPIを使った