### PR TITLE
投稿ページにおいて、「クリップボードにコピー」した結果がundefinedになるのを治す

### DIFF
--- a/app/routes/_layout.post.tsx
+++ b/app/routes/_layout.post.tsx
@@ -222,9 +222,9 @@ export default function App() {
   }, [firstSubmitFetcher.state]);
 
   const handleCopy = () => {
-    const response = firstSubmitFetcher.data as { data: { MarkdownResult: string } };
+    const response = firstSubmitFetcher.data.data.data;
     try {
-      navigator.clipboard.writeText(response?.data?.MarkdownResult);
+      navigator.clipboard.writeText(response?.MarkdownResult);
       toast.success("クリップボードにコピーしました。");
     } catch (error) {
       toast.error("クリップボードにコピーできませんでした。");


### PR DESCRIPTION
# 変更概要
- タイトル通りのため省略する