### PR TITLE
ユーザーがコメントに対するいいねボタン・よくないねボタンを押したときのフィードバックをすぐに受けられるように変更

### DIFF
--- a/app/components/CommentCard.tsx
+++ b/app/components/CommentCard.tsx
@@ -1,8 +1,7 @@
 import { useState, useRef } from "react";
 import CommentInputBox from "./CommentInputBox";
 import ClockIcon from "./icons/ClockIcon";
-import ThumbsUpIcon from "./icons/ThumbsUpIcon";
-import ThumbsDownIcon from "./icons/ThumbsDownIcon";
+import { VoteButton } from "./VoteButton";
 import RelativeDate from "./RelativeDate";
 import { z } from "zod";
 import { useForm } from "react-hook-form";
@@ -62,6 +61,8 @@ export default function CommentCard({
 
   const [isCommentLikeButtonPushed, setIsCommentLikeButtonPushed] = useState(false);
   const [isCommentDislikeButtonPushed, setIsCommentDislikeButtonPushed] = useState(false);
+  const [isCommentLikeAnimating, setIsCommentLikeAnimating] = useState(false);
+  const [isCommentDislikeAnimating, setIsCommentDislikeAnimating] = useState(false);
   
   const { setValue, getValues } = useForm<CommentVoteSchema>({
     resolver: zodResolver(commentVoteSchema),
@@ -74,10 +75,18 @@ export default function CommentCard({
     setValue("commentId", commentId);
     
     if (voteType === "like") {
-      setIsCommentLikeButtonPushed(true);
+      setIsCommentLikeAnimating(true);
+      setTimeout(() => {
+        setIsCommentLikeButtonPushed(true);
+        setIsCommentLikeAnimating(false);
+      }, 1000);
     }
     if (voteType === "dislike") {
-      setIsCommentDislikeButtonPushed(true);
+      setIsCommentDislikeAnimating(true);
+      setTimeout(() => {
+        setIsCommentDislikeButtonPushed(true);
+        setIsCommentDislikeAnimating(false);
+      }, 1000);
     }
     onCommentVote(getValues());
   };
@@ -118,40 +127,22 @@ export default function CommentCard({
       </div>
       <p className="whitespace-pre-wrap break-words">{commentContent}</p>
       <div className="flex items-center mt-4">　　　　　　
-        <div>
-          <button
-            className={`flex items-center mr-4 rounded-md px-2 py-2 bg-base-300 hover:bg-base-200 ${
-              isLiked ? "text-blue-500 font-bold" : ""
-            } comment-like-button`}
-            onClick={() => {
-              handleCommentVote("like");
-            }}
-            disabled={isCommentLikeButtonPushed || isLiked}
-            type="button"
-          >
-            <ThumbsUpIcon />
-            <p className="ml-2">
-            {likesCount}
-            </p>
-          </button>
-        </div>
-        <div>
-          <button
-            className={`flex items-center mr-4 rounded-md px-2 py-2 bg-base-300 hover:bg-base-200 ${
-              isDisliked ? "text-red-500 font-bold" : ""}
-              comment-dislike-button`}
-            onClick={() => {
-              handleCommentVote("dislike");
-            }}
-            disabled={isCommentDislikeButtonPushed || isDisliked}
-            type="button"
-          >
-            <ThumbsDownIcon />
-            <p className="ml-2">
-            {dislikesCount}
-            </p>
-          </button>
-        </div>
+        <VoteButton
+          type="like"
+          count={likesCount}
+          isAnimating={isCommentLikeAnimating}
+          isVoted={isLiked}
+          disabled={isCommentLikeButtonPushed || isLiked || isCommentLikeAnimating}
+          onClick={() => handleCommentVote("like")}
+        />
+        <VoteButton
+          type="dislike"
+          count={dislikesCount}
+          isAnimating={isCommentDislikeAnimating}
+          isVoted={isDisliked}
+          disabled={isCommentDislikeButtonPushed || isDisliked || isCommentDislikeAnimating}
+          onClick={() => handleCommentVote("dislike")}
+        />
       </div>
     <button
         className="mt-2 text-blue-500"


### PR DESCRIPTION
## ご挨拶

コンセプトに感銘を受けました。微力ながらサイトの体験向上に貢献したいと思い #87 の修正を行いました。

## 変更概要

- **コメントに対するいいねボタン・よくないねボタン** を押した際の振る舞いを **記事に対するいいねボタン・よくないねボタン** と同じものにしました。
     - [記事に対するいいねボタン・よくないねボタンと同様の実装](https://github.com/sora32127/healthy-person-emulator-dotorg/blob/9fd097d6e01593ce71cb3a4b8fddabfb5aa2d98d/app/routes/_layout.archives.%24postId.tsx#L77-L106) を施しています。
         - [`VoteButton`](https://github.com/D-ske104/healthy-person-emulator-dotorg/blob/main/app/components/VoteButton.tsx) コンポーネントを利用するように変更
         - クリックイベントのハンドラ内でアニメーション、非活性の状態管理を「記事いいね」と同様の処理に変更

## スクリーンショット

![hpe-87](https://github.com/user-attachments/assets/f6303cb3-ebeb-4578-9dc7-da9e71818469)

## Issue

closed #87

## 動作確認したところ

- **コメントに対するいいねボタン・よくないねボタン** を押したときにアニメーションする（スクリーンショット の GIFアニメを参照）
- **コメントに対するいいねボタン・よくないねボタン** を押した後、ローカル supabase `fct_comment_vote_history` テーブルにレコードが作成される
    - [fct_comment_vote_history_rows.csv](https://github.com/user-attachments/files/18814180/fct_comment_vote_history_rows.csv)

## できていないところ

- playwright が整備中のようでしたのでe2eテストは実施できていません
- db test は [`search_similar_content`](https://github.com/D-ske104/healthy-person-emulator-dotorg/blob/bee0a2351bdad27070e99821161e04df3450ec12/app/modules/db.server.ts#L182-L183) の再現が難しかったため行えていません

## 補足

別のレイヤーで処理を共通化させようとしてたらすみません