### PR TITLE
gemini-2.5-flash-liteにモデルを変更する

### DIFF
--- a/app/modules/security.server.ts
+++ b/app/modules/security.server.ts
@@ -84,7 +84,7 @@ export async function getJudgeWelcomedByGenerativeAI(postContent: string, postTi
 
   const generativeAi = new GoogleGenerativeAI(GOOGLE_GENERATIVE_API_KEY);
   const model = generativeAi.getGenerativeModel({
-      model: "gemini-1.5-flash",
+      model: "gemini-2.5-flash-lite",
       generationConfig: {
           responseMimeType: "application/json",
           responseSchema: schema,


### PR DESCRIPTION
gemini-1.5 flashが非推奨になり、404エラーが発生していたため、モデルを変更した

関連リリースノート
- https://ai.google.dev/gemini-api/docs/changelog?hl=ja#09-29-2025

エラーログ
```json
{
  "textPayload": "GoogleGenerativeAIFetchError: [GoogleGenerativeAI Error]: Error fetching from https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent: [404 Not Found] models/gemini-1.5-flash is not found for API version v1beta, or is not supported for generateContent. Call ListModels to see the list of available models and their supported methods.\n    at handleResponseNotOk (file:///workspace/node_modules/.pnpm/@google+generative-ai@0.21.0/node_modules/@google/generative-ai/dist/index.mjs:412:11)\n    at processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at makeRequest (file:///workspace/node_modules/.pnpm/@google+generative-ai@0.21.0/node_modules/@google/generative-ai/dist/index.mjs:385:9)\n    at generateContent (file:///workspace/node_modules/.pnpm/@google+generative-ai@0.21.0/node_modules/@google/generative-ai/dist/index.mjs:830:22)\n    at getJudgeWelcomedByGenerativeAI (file:///workspace/build/server/index.js?t=315532801000:2402:18)\n    at action$1 (file:///workspace/build/server/index.js?t=315532801000:5323:43)\n    at Object.callRouteAction (/workspace/node_modules/.pnpm/@remix-run+server-runtime@2.15.2_typescript@5.7.2/node_modules/@remix-run/server-runtime/dist/data.js:36:16)\n    at /workspace/node_modules/.pnpm/@remix-run+router@1.21.0/node_modules/@remix-run/router/router.ts:4899:19\n    at callLoaderOrAction (/workspace/node_modules/.pnpm/@remix-run+router@1.21.0/node_modules/@remix-run/router/router.ts:4963:16)\n    at async Promise.all (index 2) {",
  "insertId": "68dbcf5f0009c80ee52d56ab",
  "resource": {
    "type": "cloud_run_revision",
    "labels": {
      "configuration_name": "healthy-person-emulator-dotorg",
      "service_name": "healthy-person-emulator-dotorg",
      "project_id": "healthy-person-emulator",
      "revision_name": "healthy-person-emulator-dotorg-00032-xpn",
      "location": "asia-northeast1"
    }
  },
  "timestamp": "2025-09-30T12:38:55.641038Z",
  "severity": "ERROR",
  "labels": {
    "instanceId": "0069c7a9888797174333b6c7579851a57648a73e2c16a6f235b2015f720a62607b2581df0dd6724e4c452293c2c85f4c52f27d00fcfdcfafc2a1843db3f1d5312a867731c5cfbbe97b18d9bfa1869a8fadb7"
  },
  "logName": "projects/healthy-person-emulator/logs/run.googleapis.com%2Fstderr",
  "receiveTimestamp": "2025-09-30T12:38:55.645717738Z",
  "errorGroups": [
    {
      "id": "CJ7rzKCw0qX5Yw"
    }
  ]
}
```
