### PR TITLE
Prisma 定義に dim_posts.token_count を追加

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -110,6 +110,7 @@ model DimPosts {
   countDislikes             Int                       @default(0) @map("count_dislikes")
   uuid                      String                    @default(dbgenerated("uuid_generate_v4()")) @map("uuid") @db.Uuid
   content_embedding         Unsupported("vector")?
+  tokenCount                Int                       @default(0) @map("token_count")
   ogpImageUrl               String?                   @map("ogp_image_url")
   tweetIdOfFirstTweet       String?                   @map("tweet_id_of_first_tweet")
   blueskyPostUriOfFirstPost String?                   @map("bluesky_post_uri_of_first_post")


### PR DESCRIPTION
fix: #210 

---

### 変更内容

Prisma 定義に `dim_posts.token_count` / `tokenCount` を追加しました。

### 動作確認

以下のコマンドで立ち上げた後に記事が http://localhost:3000/post から投稿できること。

```bash
docker compose -f compose.dev.yaml down --rmi local
docker compose -f compose.dev.yaml up -d
```

http://localhost:3000/post で `Error: GOOGLE_GENERATIVE_API_KEY is not set` が発生するが、投稿はできている。

<img width="951" height="959" alt="image" src="https://github.com/user-attachments/assets/d2b8dd89-12f2-47a7-bdb7-8595ba53c804" />
