### PR TITLE
開発環境でGoogleログインができるようにする

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,8 @@ HPE_SESSION_SECRET=your-session-secret-key-change-this-in-production
 
 # Google OAuth
 CLIENT_URL=http://localhost:3000
-GOOGLE_CLIENT_ID=your-google-client-id
-GOOGLE_CLIENT_SECRET=your-google-client-secret
+GOOGLE_CLIENT_ID=google-client-demo-id
+GOOGLE_CLIENT_SECRET=google-client-demo-secret
 GOOGLE_REDIRECT_URI=http://localhost:3000/auth/google/callback
 
 # Google Cloud Storage


### PR DESCRIPTION
## 概要

fix: #217 

## 変更内容

Googleログインを開発環境でデモできるように、 `remix-auth` の `GoogleStrategy` をモック。

`demo@example.com` としてログインできるようにした。

### スクリーンショット


https://github.com/user-attachments/assets/89a18a05-2d60-43d0-9ade-6353405d4221

## 動作確認

ログイン→記事作成→ブックマーク→ログアウト→ログインができること

## 備考

記事編集しようとすると、作成しようとしている now_editing_pages テーブルの user_id カラムの user_profiles テーブルに対する外部キー制約でエラーとなる。

<details>

```
PrismaClientKnownRequestError: 
Invalid `prisma.nowEditingPages.upsert()` invocation:


Foreign key constraint violated: `public_now_editing_pages_user_id_fkey (index)`
    at Vn.handleRequestError (/app/node_modules/.pnpm/@prisma+client@6.2.1_prisma@5.22.0/node_modules/@prisma/client/runtime/library.js:121:7339)
    at Vn.handleAndLogRequestError (/app/node_modules/.pnpm/@prisma+client@6.2.1_prisma@5.22.0/node_modules/@prisma/client/runtime/library.js:121:6663)
    at Vn.request (/app/node_modules/.pnpm/@prisma+client@6.2.1_prisma@5.22.0/node_modules/@prisma/client/runtime/library.js:121:6370)
    at l (/app/node_modules/.pnpm/@prisma+client@6.2.1_prisma@5.22.0/node_modules/@prisma/client/runtime/library.js:130:9617)
    at Module.upsertNowEditingInfo (/app/app/modules/db.server.ts:1430:5)
    at loader (/app/app/routes/_layout.archives.edit.$postId.tsx:84:3)
    at Object.callRouteLoader (/app/node_modules/.pnpm/@remix-run+server-runtime@2.15.2_typescript@5.7.2/node_modules/@remix-run/server-runtime/dist/data.js:59:16)
    at /app/node_modules/.pnpm/@remix-run+router@1.21.0/node_modules/@remix-run/router/router.ts:4899:19
    at callLoaderOrAction (/app/node_modules/.pnpm/@remix-run+router@1.21.0/node_modules/@remix-run/router/router.ts:4963:16)
    at async Promise.all (index 1)
    at defaultDataStrategy (/app/node_modules/.pnpm/@remix-run+router@1.21.0/node_modules/@remix-run/router/router.ts:4772:17)
    at callDataStrategyImpl (/app/node_modules/.pnpm/@remix-run+router@1.21.0/node_modules/@remix-run/router/router.ts:4835:17)
    at callDataStrategy (/app/node_modules/.pnpm/@remix-run+router@1.21.0/node_modules/@remix-run/router/router.ts:3992:19)
    at loadRouteData (/app/node_modules/.pnpm/@remix-run+router@1.21.0/node_modules/@remix-run/router/router.ts:3937:19)
    at queryImpl (/app/node_modules/.pnpm/@remix-run+router@1.21.0/node_modules/@remix-run/router/router.ts:3696:20)
    at Object.query (/app/node_modules/.pnpm/@remix-run+router@1.21.0/node_modules/@remix-run/router/router.ts:3546:18)
    at handleDocumentRequest (/app/node_modules/.pnpm/@remix-run+server-runtime@2.15.2_typescript@5.7.2/node_modules/@remix-run/server-runtime/dist/server.js:275:15)
    at requestHandler (/app/node_modules/.pnpm/@remix-run+server-runtime@2.15.2_typescript@5.7.2/node_modules/@remix-run/server-runtime/dist/server.js:160:18)
    at nodeHandler (/app/node_modules/.pnpm/@remix-run+dev@2.15.2_@remix-run+react@2.15.2_react-dom@18.3.1_react@18.3.1__react@18.3_a391e5e60db39a4be181180ee2875e71/node_modules/@remix-run/dev/dist/vite/plugin.js:868:27)
    at /app/node_modules/.pnpm/@remix-run+dev@2.15.2_@remix-run+react@2.15.2_react-dom@18.3.1_react@18.3.1__react@18.3_a391e5e60db39a4be181180ee2875e71/node_modules/@remix-run/dev/dist/vite/plugin.js:871:15
```

</details>

アプリには `user_profiles` のレコードを作成するロジックがないようなので、何らかの本番にしかない仕組みでユーザー作成時などに作成されている？
