### PR TITLE
Prismaスキーマから user_profiles テーブル関連定義を削除

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -78,21 +78,11 @@ model FctCommentVoteHistory {
   @@map("fct_comment_vote_history")
 }
 
-model userProfiles {
-  userId            String            @id @map("user_id") @db.Uuid
-  userCreatedAt     DateTime          @default(now()) @map("user_created_at") @db.Timestamptz(6)
-  userEmail         String            @unique @map("user_email")
-  now_editing_pages nowEditingPages[]
-
-  @@map("user_profiles")
-}
-
 model nowEditingPages {
   postId             Int          @id @unique @default(autoincrement()) @map("post_id")
   userId             String       @map("user_id") @db.Uuid
   lastHeartBeatAtUTC DateTime     @default(dbgenerated("(now() AT TIME ZONE 'utc'::text)")) @map("last_heart_beat_at_utc") @db.Timestamptz(6)
   dim_posts          DimPosts     @relation(fields: [postId], references: [postId], onDelete: Cascade, onUpdate: Cascade, map: "public_now_editing_pages_post_id_fkey")
-  user_profiles      userProfiles @relation(fields: [userId], references: [userId], onDelete: Cascade, map: "public_now_editing_pages_user_id_fkey")
 
   @@map("now_editing_pages")
 }


### PR DESCRIPTION

## 概要

fix: #226

## 変更内容

不要になったテーブル定義を削除。

### スクリーンショット

https://github.com/user-attachments/assets/952f4ef2-989a-4a52-b057-0a5f2205be27


## 動作確認

ログイン→記事編集ができること。

## 備考

他に未使用テーブルはないか気になる。