### PR TITLE
Fix: ページ遷移時やブラウザバックを行うと確率的にエラーが発生する

### DIFF
--- a/app/routes/_layout._index.tsx
+++ b/app/routes/_layout._index.tsx
@@ -45,6 +45,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
 }
 
 export default function Feed() {
+  const loaderData = useLoaderData<typeof loader>();
+  if (!loaderData) return null;
+
   const {
     tab,
     mostRecentPosts,
@@ -54,7 +57,7 @@ export default function Feed() {
     mostRecentComments,
     randomPosts,
     randomComments,
-  } = useLoaderData<typeof loader>();
+  } = loaderData;
   return (
     <div>
       <div>

--- a/app/routes/_layout.archives.$postId.tsx
+++ b/app/routes/_layout.archives.$postId.tsx
@@ -88,6 +88,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
 }
 
 export default function Component() {
+  const loaderData = useLoaderData<typeof loader>();
+  if (!loaderData?.data) return null;
+
   const {
     data,
     likedPages,
@@ -97,7 +100,7 @@ export default function Component() {
     CF_TURNSTILE_SITEKEY,
     isAuthenticated,
     isBookmarked,
-  } = useLoaderData<typeof loader>();
+  } = loaderData;
   const [isPageLikeButtonPushed, setIsPageLikeButtonPushed] = useState(false);
   const [isPageDislikeButtonPushed, setIsPageDislikeButtonPushed] =
     useState(false);

--- a/app/routes/_layout.archives.edit.$postId.tsx
+++ b/app/routes/_layout.archives.edit.$postId.tsx
@@ -131,6 +131,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 }
 
 export default function EditPost() {
+  const loaderData = useLoaderData<typeof loader>();
+  if (!loaderData) return null;
+
   const {
     postData,
     postMarkdown,
@@ -141,7 +144,7 @@ export default function EditPost() {
     userUuid,
     editHistory,
     CF_TURNSTILE_SITEKEY,
-  } = useLoaderData<typeof loader>();
+  } = loaderData;
   const [selectedTags, setSelectedTags] = useState<string[] | null>(tagNames);
   const [isSubmitButtonOpen, setIsSubmitButtonOpen] = useState(false);
 

--- a/app/routes/_layout.bookmark.tsx
+++ b/app/routes/_layout.bookmark.tsx
@@ -34,8 +34,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
 }
 
 export default function BookmarkLayout() {
-  const { bookmarkPosts, email, pageNumber, pageSize } =
-    useLoaderData<typeof loader>();
+  const loaderData = useLoaderData<typeof loader>();
+  if (!loaderData?.bookmarkPosts) return null;
+
+  const { bookmarkPosts, email, pageNumber, pageSize } = loaderData;
   return (
     <div>
       <H1>ブックマーク</H1>

--- a/app/routes/_layout.comment.tsx
+++ b/app/routes/_layout.comment.tsx
@@ -31,6 +31,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
 export default function Comment() {
   const commentFeedData = useLoaderData<typeof loader>();
+  if (!commentFeedData?.meta) return null;
+
   const submit = useSubmit();
   const currentPage = commentFeedData.meta.currentPage;
   const totalCount = commentFeedData.meta.totalCount;

--- a/app/routes/_layout.editHistory.tsx
+++ b/app/routes/_layout.editHistory.tsx
@@ -53,7 +53,10 @@ function EditHistoryItem({ editHistory }: { editHistory: EditHistory }) {
 }
 
 export default function MyPageLayout() {
-  const { userEditHistory } = useLoaderData<typeof loader>();
+  const loaderData = useLoaderData<typeof loader>();
+  if (!loaderData?.userEditHistory) return null;
+
+  const { userEditHistory } = loaderData;
   return (
     <div className="flex flex-col gap-4">
       <H1>編集履歴</H1>

--- a/app/routes/_layout.feed.tsx
+++ b/app/routes/_layout.feed.tsx
@@ -83,6 +83,8 @@ export async function action({ request }: ActionFunctionArgs) {
 
 export default function Feed() {
   const postData = useLoaderData<typeof loader>();
+  if (!postData?.meta) return null;
+
   const chunkSize = postData.meta.chunkSize;
   const totalPages = Math.ceil(postData.meta.totalCount / chunkSize);
   const type = postData.meta.type;

--- a/app/routes/_layout.post.tsx
+++ b/app/routes/_layout.post.tsx
@@ -58,7 +58,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
 }
 
 export default function App() {
-  const { tags, stopWords, turnStileSiteKey } = useLoaderData<typeof loader>();
+  const loaderData = useLoaderData<typeof loader>();
+  if (!loaderData) return null;
+
+  const { tags, stopWords, turnStileSiteKey } = loaderData;
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [createdTags, setCreatedTags] = useState<string[]>([]);
 

--- a/app/routes/_layout.search.tsx
+++ b/app/routes/_layout.search.tsx
@@ -93,7 +93,10 @@ export async function action({ request }: ActionFunctionArgs) {
 }
 
 export default function LightSearch() {
-  const { searchAssetURL, tagsAssetURL } = useLoaderData<typeof loader>();
+  const loaderData = useLoaderData<typeof loader>();
+  if (!loaderData) return null;
+
+  const { searchAssetURL, tagsAssetURL } = loaderData;
   const [lightSearchHandler, setLightSearchHandler] =
     useState<LightSearchHandler | null>(null);
   const [searchParams, setSearchParams] = useSearchParams();

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -8,7 +8,6 @@ import {
 } from '@remix-run/react';
 import PostIcon from '~/components/icons/PostIcon';
 import SearchIcon from '~/components/icons/SearchIcon';
-import LogoutIcon from '~/components/icons/LogoutIcon';
 import MenuIcon from '~/components/icons/MenuIcon';
 import ThemeSwitcher from '~/components/ThemeSwitcher';
 import { Footer } from '~/components/Footer';
@@ -223,7 +222,10 @@ export default function Component() {
   const [searchQuery, setSearchQuery] = useState('');
   const [isSidebarExpanded, setIsSidebarExpanded] = useState(false);
   const [_, setAuthState] = useAtom(setAuthStateAtom);
-  const { userObject } = useLoaderData<typeof loader>();
+  const loaderData = useLoaderData<typeof loader>();
+  if (!loaderData) return null;
+
+  const { userObject } = loaderData;
   const isLoginModalOpen = useAtomValue(getIsLoginModalOpenAtom);
   const setIsLoginModalOpen = useSetAtom(setIsLoginModalOpenAtom);
 


### PR DESCRIPTION
## 概要

Fix: #232 

## 変更内容

`loaderData` が未初期化の場合は `null` を返すことで、Remixにページ再レンダリングを促す。

## 動作確認

サーバー起動後、フィードや記事編集でエラーが発生しないこと。

## 備考

https://github.com/remix-run/react-router/discussions/11461