### PR TITLE
トップページ「最新の投稿を見る」ボタン幅をそろえる

### DIFF
--- a/app/routes/_layout._index.tsx
+++ b/app/routes/_layout._index.tsx
@@ -69,7 +69,7 @@ export default function Feed() {
             identifier="latest"
           >
             <button
-              className="rounded-md block w-full max-w-[800px] px-10 py-2 text-center my-4 bg-base-200 hover:bg-base-300 mx-auto"
+              className="rounded-md block w-full max-w-[400px] px-4 py-2 text-center my-4 bg-base-200 mx-auto hover:bg-base-300"
               type="button"
             >
               <NavLink


### PR DESCRIPTION
## 概要
Fix: #230
## 変更内容
「最新の投稿を見る」だけsectionいっぱいに広がっているので、他に揃えた。

### スクリーンショット
http://localhost:3000/?referrer=fromMenu
<img width="943" height="955" alt="image" src="https://github.com/user-attachments/assets/6587fb21-677b-4c0f-96a6-c7752a7e1053" />

## 動作確認

ボタン幅が他2つのボタンと揃っていること。
