### PR TITLE
ランダムページの見出し文言を変更

### DIFF
--- a/app/routes/_layout._index.tsx
+++ b/app/routes/_layout._index.tsx
@@ -131,12 +131,12 @@ export default function Feed() {
           className="tab-content"
           style={{ display: tab === 'random' ? 'block' : 'none' }}
         >
-          <PostSection title="ランダム" posts={randomPosts} identifier="random">
+          <PostSection title="ランダム投稿" posts={randomPosts} identifier="random">
             <div className="flex justify-center">
               <ReloadButton />
             </div>
           </PostSection>
-          <CommentSection title="ランダム" comments={randomComments}>
+          <CommentSection title="ランダムコメント" comments={randomComments}>
             <div className="flex justify-center">
               <ReloadButton />
             </div>


### PR DESCRIPTION
## 概要
Fix: #229
## 変更内容

ランダムページで、セクション見出しがどちらも「ランダム」となっている。それぞれ「ランダム投稿」・「ランダムコメント」とわかりやすくした。

### スクリーンショット
http://localhost:3000/?tab=random

|Before|After|
|-|-|
|<img width="949" height="964" alt="Screenshot 2025-11-29 at 17 02 43" src="https://github.com/user-attachments/assets/2fb977c4-a6ab-498f-9526-a40423437394" />|<img width="947" height="957" alt="image" src="https://github.com/user-attachments/assets/d395267f-6772-4cb9-be61-6fc7a26b226d" />|

## 動作確認

意図した箇所の文言が変わっていること
