### PR TITLE
2行以上の長いコメントはコメント一覧で省略表示する

### DIFF
--- a/app/components/CommentShowCard.tsx
+++ b/app/components/CommentShowCard.tsx
@@ -39,7 +39,7 @@ export default function CommentShowCard({
         <div className="w-6 h-6">
           <CommentIcon />
         </div>
-        <p className="text-base-content comment-content">{commentContent}</p>
+        <p className="text-base-content comment-content line-clamp-2">{commentContent}</p>
       </div>
       <div className="grid grid-cols-[auto_1fr] gap-2 items-center">
         <div className="w-6 h-6">


### PR DESCRIPTION
## 概要
fix: #241 
## 変更内容

2行以上の長いコメントはコメント一覧で省略表示するように修正した。
これにより、長いURLのような文章を張り込まれてもスタイルが壊れないようになった。

### スクリーンショット

|Before|After|
|-|-|
|<img width="938" height="1160" alt="image" src="https://github.com/user-attachments/assets/2537a1dc-a037-484d-a344-b372dec30d2e" />|<img width="938" height="1160" alt="image" src="https://github.com/user-attachments/assets/7be59335-630b-4a39-9af1-32dcfd5e389e" />|

## 動作確認

長いURLをコメントして適切に省略されること。
