### PR TITLE
「入力内容をリセット」ボタン押下時HTML仕様違反を修正

### DIFF
--- a/app/components/Modal.tsx
+++ b/app/components/Modal.tsx
@@ -28,11 +28,11 @@ export function Modal({
           </div>
         )}
       </div>
-      <form method="dialog" className="modal-backdrop">
-        <button type="button" onClick={onClose}>
+      <div className="modal-backdrop">
+        <button type="button" onClick={onClose} aria-label="close">
           close
         </button>
-      </form>
+      </div>
     </dialog>
   );
 }


### PR DESCRIPTION
## 概要
fix: #247 
## 変更内容
「入力内容をリセット」ボタン押下時に発生するHTML仕様違反を修正。
### スクリーンショット

https://github.com/user-attachments/assets/b530fa6b-0d83-4c0b-bb5f-8148993bbc17


## 動作確認
「入力内容をリセット」ボタン押下時に警告が発生しないこと。
バックドロップクリックでダイアログが閉じること。
