### PR TITLE
fix: preview 環境の AutomationContainer DO を v3 deleted_classes で削除

### DIFF
--- a/wrangler.preview.toml
+++ b/wrangler.preview.toml
@@ -84,6 +84,16 @@ secret_name = "AUTOMATION_DRY_RUN"
 
 # GCS_CREDENTIALS is set via `wrangler secret put GCS_CREDENTIALS`
 
+# --- Migrations: AutomationContainer は preview 環境にも DO 実体があったため、
+# 本番と同じく v3 で deleted_classes を実行して削除する ---
+[[migrations]]
+tag = "v2"
+new_sqlite_classes = ["AutomationContainer"]
+
+[[migrations]]
+tag = "v3"
+deleted_classes = ["AutomationContainer"]
+
 # --- Module rules: resvg-wasm と NotoSansJP TTF を Worker バンドルに含める ---
 [[rules]]
 type = "CompiledWasm"


### PR DESCRIPTION
## Summary

PR #349 で AutomationContainer DO を削除した際、preview 環境（\`healthy-person-emulator-dotorg-preview\`）も DO 実体を持っていたため、\`wrangler.preview.toml\` にも v3 \`deleted_classes\` migration が必要だった。これを欠いた結果、PR #349 の preview デプロイが以下のエラーで失敗:

\`\`\`
New version of script does not export class 'AutomationContainer'
which is depended on by existing Durable Objects.
\`\`\`

本番の \`wrangler.toml\` と同じ構成（v2 履歴 + v3 \`deleted_classes\`）を \`wrangler.preview.toml\` にも追加し、次回 preview デプロイを通せるようにする。

## Test plan

- [ ] このPR の preview デプロイ（preview-deploy.yml）が成功すること
- [ ] preview Cloudflare ダッシュボードで AutomationContainer が listing から消えること

🤖 Generated with [Claude Code](https://claude.com/claude-code)