### PR TITLE
Google Tag Managerを導入した

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -37,10 +37,27 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
         <meta property="og:site_name" content="健常者エミュレータ事例集" />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-NV8MBBMS');`,
+          }}
+        />
         <Meta />
         <Links />
       </head>
       <body>
+        <noscript>
+          <iframe
+            src="https://www.googletagmanager.com/ns.html?id=GTM-NV8MBBMS"
+            height="0"
+            width="0"
+            style={{ display: 'none', visibility: 'hidden' }}
+          />
+        </noscript>
         <PageTransitionProgressBar />
         {children}
         <ScrollRestoration />

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -53,6 +53,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <noscript>
           <iframe
             src="https://www.googletagmanager.com/ns.html?id=GTM-NV8MBBMS"
+            title="Google Tag Manager"
             height="0"
             width="0"
             style={{ display: 'none', visibility: 'hidden' }}


### PR DESCRIPTION
# 概要

- サイト全体のアクセス解析やタグ管理を行うための基盤が用意されていない
- Google Analyticsや広告計測などのタグを個別にコードへ埋め込むと、追加・修正のたびにデプロイが必要になり管理コストが高い
- React Routerの`Layout`コンポーネントにGoogle Tag Manager（`GTM-NV8MBBMS`）のスニペットを組み込み、以降のタグはGTM側で管理できるようにした

# 変更内容

## `app/root.tsx` にGTMスニペットを2箇所追加

GTMの公式インストール手順に沿い、`Layout` コンポーネント内の`<head>`と`<body>`それぞれにスニペットを配置した。

| 配置場所 | 内容 | JSX対応 |
|---|---|---|
| `<head>` 内（`<Meta />`/`<Links />` の前） | gtm.jsを読み込むインラインスクリプト | `dangerouslySetInnerHTML` で文字列として渡す |
| `<body>` 直後 | JavaScript無効時用の`<iframe>`を含む`<noscript>` | `style` 属性をJSXオブジェクト形式に変換 |

# 確認したこと

- [x] `pnpm format` でフォーマットが通ること
- [ ] デプロイ後、GTMの「タグアシスタント」または `window.dataLayer` が初期化されていることをブラウザで確認する（マージ後）

# 参考

- [Google Tag Manager - インストール手順](https://developers.google.com/tag-platform/tag-manager/web)

# 補足

- 本PRはGTMの読み込みのみを行う。実際の計測タグ（GA4等）はGTM管理画面側で追加・公開する運用とする