### PR TITLE
fix: SNS投稿エラーの分類をHTTP status基準に修正し、4xxをterminal扱いにした

### DIFF
--- a/app/modules/automation.server.ts
+++ b/app/modules/automation.server.ts
@@ -372,16 +372,23 @@ export async function recoverStaleJobs(env: CloudflareEnv): Promise<RecoverStale
 
 // ─── Helpers ────────────────────────────────────────────────
 
-function classifyError(err: unknown): 'terminal' | 'retryable' | 'ambiguous' {
+export function classifyError(err: unknown): 'terminal' | 'retryable' | 'ambiguous' {
   const msg = err instanceof Error ? err.message : String(err);
 
-  // Terminal: auth failures
-  if (/401|403|Unauthorized|Forbidden/i.test(msg)) return 'terminal';
+  // Extract HTTP status from "(NNN)" — all SNS clients throw with this format
+  const statusMatch = msg.match(/\((\d{3})\)/);
+  const status = statusMatch ? Number(statusMatch[1]) : null;
 
-  // Retryable: rate limits, server errors
-  if (/429|500|502|503|504|rate.?limit|timeout/i.test(msg)) return 'retryable';
+  if (status !== null) {
+    // 408 (Request Timeout) and 429 (Too Many Requests) recover on their own
+    if (status === 408 || status === 429) return 'retryable';
+    // Other 4xx (auth, payment, validation, etc.) need human intervention
+    if (status >= 400 && status < 500) return 'terminal';
+    // 5xx: transient server-side issues
+    if (status >= 500 && status < 600) return 'retryable';
+  }
 
-  // Connection errors are ambiguous
+  // Network-level failures: request may or may not have been delivered
   if (/ECONNRESET|ECONNREFUSED|ETIMEDOUT|fetch failed/i.test(msg)) return 'ambiguous';
 
   return 'ambiguous';

--- a/tests/modules/automation.server.test.ts
+++ b/tests/modules/automation.server.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { classifyError } from '~/modules/automation.server';
+
+describe('classifyError', () => {
+  describe('4xx: terminal (human intervention required)', () => {
+    it.each([
+      ['400 Bad Request', 'API failed (400): malformed request'],
+      ['401 Unauthorized', 'Twitter create tweet failed (401): unauthorized'],
+      ['402 CreditsDepleted', 'Twitter create tweet failed (402): {"title":"CreditsDepleted"}'],
+      ['403 Forbidden', 'Bluesky post failed (403): forbidden'],
+      ['404 Not Found', 'Misskey note failed (404): not found'],
+      ['422 Unprocessable', 'API failed (422): validation error'],
+    ])('%s → terminal', (_label, msg) => {
+      expect(classifyError(new Error(msg))).toBe('terminal');
+    });
+  });
+
+  describe('retryable: rate limits, timeouts, server errors', () => {
+    it.each([
+      ['408 Request Timeout', 'API failed (408): timeout'],
+      ['429 Too Many Requests', 'API failed (429): rate limit'],
+      ['500 Internal Server Error', 'API failed (500): server error'],
+      ['502 Bad Gateway', 'API failed (502)'],
+      ['503 Service Unavailable', 'API failed (503)'],
+      ['504 Gateway Timeout', 'API failed (504)'],
+    ])('%s → retryable', (_label, msg) => {
+      expect(classifyError(new Error(msg))).toBe('retryable');
+    });
+  });
+
+  describe('network errors: ambiguous (delivery unknown)', () => {
+    it.each([
+      ['ECONNRESET', 'fetch failed: ECONNRESET'],
+      ['ECONNREFUSED', 'connect ECONNREFUSED 1.2.3.4:443'],
+      ['ETIMEDOUT', 'request ETIMEDOUT'],
+      ['fetch failed (no status)', 'fetch failed'],
+    ])('%s → ambiguous', (_label, msg) => {
+      expect(classifyError(new Error(msg))).toBe('ambiguous');
+    });
+  });
+
+  describe('unknown patterns', () => {
+    it('non-Error value is coerced to string', () => {
+      expect(classifyError('Twitter create tweet failed (402): nope')).toBe('terminal');
+    });
+
+    it('does not falsely match 3-digit codes inside JSON bodies', () => {
+      // Twitter error codes (e.g. "code":416) live inside JSON without parentheses
+      expect(classifyError(new Error('something: {"code":416,"message":"x"}'))).toBe('ambiguous');
+    });
+
+    it('completely unknown error → ambiguous', () => {
+      expect(classifyError(new Error('something exploded'))).toBe('ambiguous');
+    });
+  });
+});


### PR DESCRIPTION
# 概要

- 2026-05-14 以降、X API のクレジット枯渇 (HTTP 402 CreditsDepleted) で Twitter 投稿が止まっていたが、9日間気付けなかった
- 原因は `classifyError` が 402 を `ambiguous` (→ `unknown` ステータス) として残し、`failed` に落とさず可視化されなかったこと
- HTTP status を抽出して 408/429 のみ retryable、他の 4xx は全て terminal、5xx は retryable と分類し直し、ユニットテストを追加した

# 変更内容

## `classifyError` の分類ロジック刷新 (`app/modules/automation.server.ts`)

エラーメッセージから `(\d{3})` で HTTP status を抽出し、status ベースで分類する形に変更。テスト容易性のため `export` を追加。

| HTTP status | 分類 | 理由 |
|---|---|---|
| 400 / 401 / 402 / 403 / 404 / 422 など | **terminal** | クライアント側起因。人が対応しないと回復しない |
| 408 | retryable | Request Timeout は一時的 |
| 429 | retryable | Rate limit は時間経過で回復 |
| 5xx 全般 | retryable | サーバ側起因の一時障害 |
| ECONNRESET / ECONNREFUSED / ETIMEDOUT / fetch failed | ambiguous | リクエストが届いたか不明 |
| 上記いずれにも当たらない | ambiguous | 安全側で再送せず保留 |

これにより、今後 402 系の課金トラブルが起きた場合は `failed` ステータスに落ち、`recoverStaleJobs` の再 enqueue 対象からも外れる（無限リトライ防止）。

## ユニットテストを追加 (`tests/modules/automation.server.test.ts`)

`classifyError` の分類網羅テストを新規作成（19 ケース）。

- 4xx terminal: 400/401/402/403/404/422
- retryable: 408/429/500/502/503/504
- network ambiguous: ECONNRESET/ECONNREFUSED/ETIMEDOUT/fetch failed
- 偽陽性チェック: Twitter エラーレスポンス JSON 内の `"code":416` のような3桁数値を 4xx として誤検知しないこと（`(\d{3})` は括弧囲みのみマッチ）

# 確認したこと

- [x] `pnpm test tests/modules/automation.server.test.ts` で 19/19 pass
- [x] 復旧作業として、`unknown` で滞留していた 11 件 (post_id 48848-48859) を手動で Queue へ再投入し、全て `sent` に遷移したことを D1 で確認済み（このPR適用前の状態で実施）

# 参考

- [Pricing - X (公式)](https://docs.x.com/x-api/getting-started/pricing) — pay-per-use と URL 付き投稿 \$0.20/件 の根拠
- [Important Update: Legacy X API Basic Plans Are Moving to Pay-Per-Use](https://devcommunity.x.com/t/important-update-legacy-x-api-basic-plans-are-moving-to-pay-per-use-ppu/266305)

# 補足

- このPRでは「`failed` が出たら通知する」仕組みまでは入れていない。現状 cron 実行ログ (`[scheduled] cron=*/10 ... ogp: posts=N enqueued=M`) には `failed` 件数が出ないので、本質的な早期検知には別途、healthcheck.io / Slack 通知 or ログ集約が必要
- `recoverStaleJobs` は `pending` と古い `queued` のみを対象とするため、`unknown` 状態のジョブは依然として recovery 対象外。今回の修正で `unknown` 自体が発生しにくくなる（408/429 含めて network failure 系のみ）が、もし将来発生した場合は今回のように手動で D1 を `pending` に戻す必要がある

🤖 Generated with [Claude Code](https://claude.com/claude-code)