### PR TITLE
feat: AIエージェント向けに検索JSON APIを追加した

### DIFF
--- a/app/modules/markdown.server.ts
+++ b/app/modules/markdown.server.ts
@@ -1,0 +1,22 @@
+import { NodeHtmlMarkdown } from 'node-html-markdown';
+
+const converter = new NodeHtmlMarkdown();
+
+export function htmlToMarkdown(html: string): string {
+  return converter.translate(html);
+}
+
+export function wantsMarkdown(request: Request): boolean {
+  const accept = request.headers.get('accept') ?? '';
+  return /\btext\/markdown\b/i.test(accept);
+}
+
+export function markdownResponse(body: string, cacheMaxAgeSec = 300): Response {
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': `public, max-age=${cacheMaxAgeSec}`,
+      Vary: 'Accept',
+    },
+  });
+}

--- a/app/routes/_layout._index.tsx
+++ b/app/routes/_layout._index.tsx
@@ -11,6 +11,45 @@ import ReloadButton from '~/components/ReloadButton';
 import PostSection from '~/components/PostSection';
 import CommentSection from '~/components/CommentSection';
 import { commonMetaFunction } from '~/utils/commonMetafunction';
+import { markdownResponse, wantsMarkdown } from '~/modules/markdown.server';
+
+function renderHomeMarkdown(data: {
+  latest: { postId: number; postTitle: string; postDateGmt: Date }[];
+  voted: { postId: number; postTitle: string; countLikes: number }[];
+}): string {
+  const lines: string[] = [];
+  lines.push('# 健常者エミュレータ事例集');
+  lines.push('');
+  lines.push(
+    '社会生活やコミュニケーションに関する暗黙知を言語化・集積し、知識のギャップを集団で補うためのプラットフォーム。',
+  );
+  lines.push('');
+  lines.push('- サイト: https://healthy-person-emulator.org');
+  lines.push('- フィード: https://healthy-person-emulator.org/feed.xml');
+  lines.push('- サイトマップ: https://healthy-person-emulator.org/sitemap.xml');
+  lines.push(
+    '- 各記事のMarkdown版: `https://healthy-person-emulator.org/archives/{postId}.md` または `Accept: text/markdown` ヘッダー付きで記事URLにリクエスト',
+  );
+  lines.push('');
+  lines.push('## 最新の投稿');
+  lines.push('');
+  for (const p of data.latest) {
+    const date = new Date(p.postDateGmt).toISOString().slice(0, 10);
+    lines.push(
+      `- [${p.postTitle}](https://healthy-person-emulator.org/archives/${p.postId}) — ${date}`,
+    );
+  }
+  lines.push('');
+  lines.push('## 最近いいねされた投稿');
+  lines.push('');
+  for (const p of data.voted) {
+    lines.push(
+      `- [${p.postTitle}](https://healthy-person-emulator.org/archives/${p.postId}) — 👍 ${p.countLikes}`,
+    );
+  }
+  lines.push('');
+  return lines.join('\n');
+}
 
 export const meta: MetaFunction = () => {
   const commonMeta = commonMetaFunction({
@@ -32,6 +71,16 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const mostRecentComments = await getFeedComments(1, 'timeDesc');
   const randomPosts = await getRandomPosts();
   const randomComments = await getRandomComments();
+
+  if (wantsMarkdown(request)) {
+    throw markdownResponse(
+      renderHomeMarkdown({
+        latest: mostRecentPosts.result,
+        voted: recentVotedPosts.result,
+      }),
+    );
+  }
+
   return {
     tab,
     mostRecentPosts,

--- a/app/routes/_layout.readme.tsx
+++ b/app/routes/_layout.readme.tsx
@@ -71,6 +71,11 @@ const faqData: FAQItem[] = [
     answer:
       '発見ありがとうございます！[Discord](https://t.co/SOg8HEB1Ga)（当ガイドラインに招待リンクがあります）の「#エンジニアリング議論」チャンネルで連絡をいただくか、管理人の[XのDM](https://x.com/messages/compose?recipient_id=1249916069344473088)までご連絡ください。',
   },
+  {
+    question: 'AIから健常者エミュレータ事例集を検索できますか？',
+    answer:
+      'できます。`/api/search` という公開JSON APIを用意しています。詳細はサイト説明の[「AIから健常者エミュレータ事例集を検索する方法」](/readme#ai-search)をご覧ください。',
+  },
 ];
 
 // FAQアイテムコンポーネント
@@ -211,6 +216,107 @@ export default function Component() {
         <li>SNSに投稿される際は、5W1H+Then状況説明の箇所が画像として表示されます</li>
         <li>10分に一回の頻度で更新されます</li>
       </ul>
+
+      <div id="ai-search">
+        <H2>AIから健常者エミュレータ事例集を検索する方法</H2>
+        <p>
+          ChatGPT・Claude・Gemini
+          などのAIエージェントから、健常者エミュレータ事例集の投稿を検索するためのJSON
+          APIを公開しています。スクレイピング不要で、検索結果をそのまま構造化データとして取得できます。
+        </p>
+        <H3>エンドポイント</H3>
+        <ul>
+          <li>
+            <code>GET https://healthy-person-emulator.org/api/search</code>
+          </li>
+          <li>
+            認証不要・CORS対応・<code>Content-Type: application/json</code>
+          </li>
+        </ul>
+        <H3>クエリパラメータ</H3>
+        <ul>
+          <li>
+            <code>q</code>: 検索キーワード（記事タイトル・本文を部分一致検索）。省略可
+          </li>
+          <li>
+            <code>tags</code>: タグ名をスペース区切りで指定（例:{' '}
+            <code>tags=コミュニケーション 対人関係</code>
+            ）。複数指定時はAND条件。省略可
+          </li>
+          <li>
+            <code>orderby</code>: 並び順。
+            <code>timeDesc</code>（新着順・デフォルト） /<code>timeAsc</code>（古い順） /
+            <code>like</code>（いいね順）
+          </li>
+          <li>
+            <code>page</code>: ページ番号（1始まり、デフォルト1）
+          </li>
+          <li>
+            <code>pageSize</code>: 1ページの件数（デフォルト10、最大50）
+          </li>
+        </ul>
+        <H3>使用例</H3>
+        <ul>
+          <li>
+            キーワード検索: <code>/api/search?q=挨拶&amp;pageSize=5</code>
+          </li>
+          <li>
+            タグ絞り込み＋いいね順:{' '}
+            <code>/api/search?tags=コミュニケーション&amp;orderby=like</code>
+          </li>
+          <li>
+            ページング: <code>/api/search?q=会話&amp;page=2&amp;pageSize=20</code>
+          </li>
+        </ul>
+        <H3>レスポンス形式</H3>
+        <p>レスポンスは以下3つのフィールドからなるJSONオブジェクトです。</p>
+        <ul>
+          <li>
+            <code>metadata</code>: 検索条件のエコーバック・総件数・総ページ数・次ページの有無
+          </li>
+          <li>
+            <code>tagCounts</code>: 検索結果に含まれるタグごとの件数（タグ絞り込みの参考用）
+          </li>
+          <li>
+            <code>results</code>: 投稿の配列。各要素は以下のフィールドを持ちます
+            <ul>
+              <li>
+                <code>postId</code>: 投稿ID
+              </li>
+              <li>
+                <code>postTitle</code>: タイトル
+              </li>
+              <li>
+                <code>postUrl</code>:
+                投稿の絶対URL（記事本文はこのURLをHTMLとして取得して読んでください）
+              </li>
+              <li>
+                <code>postDateGmt</code>: 投稿日時（ISO 8601, UTC）
+              </li>
+              <li>
+                <code>countLikes</code> / <code>countDislikes</code> / <code>countComments</code>:
+                各種カウント
+              </li>
+              <li>
+                <code>tagNames</code>: 紐づくタグ名の配列
+              </li>
+            </ul>
+          </li>
+        </ul>
+        <H3>注意事項</H3>
+        <ul>
+          <li>
+            このAPIは検索結果（タイトル・メタデータ）のみを返します。本文はサイト上の記事ページから取得してください
+          </li>
+          <li>
+            短時間に過度なリクエストを送信した場合、Cloudflareにより制限される可能性があります
+          </li>
+          <li>
+            投稿データはGPL-3.0ライセンスの元、人間および機械の両方が自由に利用できますが、出典として{' '}
+            <code>healthy-person-emulator.org</code> を明示してください
+          </li>
+        </ul>
+      </div>
 
       <H2>開発について</H2>
       <ul>

--- a/app/routes/_layout.readme.tsx
+++ b/app/routes/_layout.readme.tsx
@@ -74,7 +74,7 @@ const faqData: FAQItem[] = [
   {
     question: 'AIから健常者エミュレータ事例集を検索できますか？',
     answer:
-      'できます。`/api/search` という公開JSON APIを用意しています。詳細はサイト説明の[「AIから健常者エミュレータ事例集を検索する方法」](/readme#ai-search)をご覧ください。',
+      'できます。公開JSON API `/api/search` を用意しています。詳細はサイト説明の[「AIから健常者エミュレータ事例集を検索する方法」](/readme#ai-search)をご覧ください。',
   },
 ];
 

--- a/app/routes/_layout.readme.tsx
+++ b/app/routes/_layout.readme.tsx
@@ -221,19 +221,25 @@ export default function Component() {
         <H2>AIから健常者エミュレータ事例集を検索する方法</H2>
         <p>
           ChatGPT・Claude・Gemini
-          などのAIエージェントから、健常者エミュレータ事例集の投稿を検索するためのJSON
-          APIを公開しています。スクレイピング不要で、検索結果をそのまま構造化データとして取得できます。
+          などのAIエージェントから、健常者エミュレータ事例集の投稿を検索・取得するためのJSON
+          APIを公開しています。スクレイピング不要で、検索結果や本文をそのまま構造化データとして取得できます。
         </p>
-        <H3>エンドポイント</H3>
+        <p>用意しているエンドポイントは2つです。</p>
         <ul>
           <li>
-            <code>GET https://healthy-person-emulator.org/api/search</code>
+            <code>GET /api/search</code> — キーワード・タグで投稿を検索する
           </li>
           <li>
-            認証不要・CORS対応・<code>Content-Type: application/json</code>
+            <code>GET /api/posts/:postId</code> — 投稿IDから本文・コメント・タグなどを取得する
           </li>
         </ul>
-        <H3>クエリパラメータ</H3>
+        <p>
+          どちらも認証不要・CORS対応・<code>Content-Type: application/json</code>。 ベースURLは{' '}
+          <code>https://healthy-person-emulator.org</code>。
+        </p>
+        <H3>検索API: GET /api/search</H3>
+        <p>キーワード・タグで投稿一覧（タイトル・メタデータ）を取得します。</p>
+        <p>クエリパラメータ:</p>
         <ul>
           <li>
             <code>q</code>: 検索キーワード（記事タイトル・本文を部分一致検索）。省略可
@@ -255,7 +261,7 @@ export default function Component() {
             <code>pageSize</code>: 1ページの件数（デフォルト10、最大50）
           </li>
         </ul>
-        <H3>使用例</H3>
+        <p>使用例:</p>
         <ul>
           <li>
             キーワード検索: <code>/api/search?q=挨拶&amp;pageSize=5</code>
@@ -268,7 +274,6 @@ export default function Component() {
             ページング: <code>/api/search?q=会話&amp;page=2&amp;pageSize=20</code>
           </li>
         </ul>
-        <H3>レスポンス形式</H3>
         <p>レスポンスは以下3つのフィールドからなるJSONオブジェクトです。</p>
         <ul>
           <li>
@@ -281,14 +286,13 @@ export default function Component() {
             <code>results</code>: 投稿の配列。各要素は以下のフィールドを持ちます
             <ul>
               <li>
-                <code>postId</code>: 投稿ID
+                <code>postId</code>: 投稿ID（本文取得APIに渡す値）
               </li>
               <li>
                 <code>postTitle</code>: タイトル
               </li>
               <li>
-                <code>postUrl</code>:
-                投稿の絶対URL（記事本文はこのURLをHTMLとして取得して読んでください）
+                <code>postUrl</code>: 投稿の絶対URL
               </li>
               <li>
                 <code>postDateGmt</code>: 投稿日時（ISO 8601, UTC）
@@ -303,11 +307,59 @@ export default function Component() {
             </ul>
           </li>
         </ul>
-        <H3>注意事項</H3>
+
+        <H3>本文取得API: GET /api/posts/:postId</H3>
+        <p>
+          検索APIで得た <code>postId</code>{' '}
+          を使い、個別投稿の本文・コメント・タグ・関連投稿等の詳細を取得します。
+        </p>
+        <p>パスパラメータ:</p>
         <ul>
           <li>
-            このAPIは検索結果（タイトル・メタデータ）のみを返します。本文はサイト上の記事ページから取得してください
+            <code>postId</code>:
+            投稿ID（正の整数）。不正な値の場合は400、該当投稿が存在しない場合は404を返します
           </li>
+        </ul>
+        <p>使用例:</p>
+        <ul>
+          <li>
+            <code>/api/posts/12345</code>
+          </li>
+        </ul>
+        <p>レスポンスは投稿の詳細を表すJSONオブジェクトです。主なフィールド:</p>
+        <ul>
+          <li>
+            <code>postTitle</code>: タイトル
+          </li>
+          <li>
+            <code>postContentHtml</code>: 投稿本文（HTML形式。サイト上の表示と同じマークアップ）
+          </li>
+          <li>
+            <code>postDateGmt</code>: 投稿日時（ISO 8601, UTC）
+          </li>
+          <li>
+            <code>tags</code>: 紐づくタグの配列（<code>tagName</code> / <code>tagId</code>）
+          </li>
+          <li>
+            <code>comments</code>: コメントの配列（投稿者名・本文・日時・親コメントID等）
+          </li>
+          <li>
+            <code>similarPosts</code>: 類似投稿の配列（Cloudflare Vectorize ベース）
+          </li>
+          <li>
+            <code>previousPost</code> / <code>nextPost</code>: 前後の投稿
+          </li>
+          <li>
+            <code>countLikes</code> / <code>countDislikes</code> / <code>countBookmarks</code> /{' '}
+            <code>countComments</code>: 各種カウント
+          </li>
+          <li>
+            <code>ogpImageUrl</code>: OGP画像URL
+          </li>
+        </ul>
+
+        <H3>注意事項</H3>
+        <ul>
           <li>
             短時間に過度なリクエストを送信した場合、Cloudflareにより制限される可能性があります
           </li>

--- a/app/routes/api.posts.$postId.tsx
+++ b/app/routes/api.posts.$postId.tsx
@@ -1,0 +1,92 @@
+/**
+ * 投稿本文取得API（外部公開）
+ * 検索API（/api/search）でヒットしたpostIdから、本文・コメント・タグ等の詳細を取得する。
+ *
+ * GET /api/posts/:postId
+ */
+import type { LoaderFunctionArgs } from 'react-router';
+import { ArchiveDataEntry } from '~/modules/db.server';
+
+function jsonError(status: number, message: string) {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Access-Control-Allow-Origin': '*',
+    },
+  });
+}
+
+export async function loader({ params, request }: LoaderFunctionArgs) {
+  const postIdParam = params.postId;
+  const postId = Number(postIdParam);
+  if (!Number.isInteger(postId) || postId < 1) {
+    return jsonError(400, 'postId must be a positive integer');
+  }
+
+  let entry: ArchiveDataEntry;
+  try {
+    entry = await ArchiveDataEntry.getData(postId);
+  } catch (e) {
+    if (e instanceof Response && e.status === 404) {
+      return jsonError(404, 'Post not found');
+    }
+    throw e;
+  }
+
+  const origin = new URL(request.url).origin;
+  const payload = {
+    postId: entry.postId,
+    postTitle: entry.postTitle,
+    postUrl: `${origin}/archives/${entry.postId}`,
+    postDateGmt: entry.postDateGmt.toISOString(),
+    postContentHtml: entry.postContent,
+    commentStatus: entry.commentStatus,
+    countLikes: entry.countLikes,
+    countDislikes: entry.countDislikes,
+    countBookmarks: entry.countBookmarks,
+    countComments: entry.comments.length,
+    ogpImageUrl: entry.ogpImageUrl,
+    isWelcomed: entry.isWelcomed,
+    isWelcomedExplanation: entry.isWelcomedExplanation,
+    tags: entry.tags.map((t) => ({ tagName: t.tagName, tagId: t.tagId })),
+    comments: entry.comments.map((c) => ({
+      commentId: c.commentId,
+      commentDateGmt: c.commentDateGmt.toISOString(),
+      commentAuthor: c.commentAuthor,
+      commentContent: c.commentContent,
+      likesCount: c.likesCount,
+      dislikesCount: c.dislikesCount,
+      commentParent: c.commentParent,
+    })),
+    similarPosts: entry.similarPosts.map((p) => ({
+      postId: p.postId,
+      postTitle: p.postTitle,
+      postUrl: `${origin}/archives/${p.postId}`,
+    })),
+    previousPost: entry.previousPost
+      ? {
+          postId: entry.previousPost.postId,
+          postTitle: entry.previousPost.postTitle,
+          postUrl: `${origin}/archives/${entry.previousPost.postId}`,
+        }
+      : null,
+    nextPost: entry.nextPost
+      ? {
+          postId: entry.nextPost.postId,
+          postTitle: entry.nextPost.postTitle,
+          postUrl: `${origin}/archives/${entry.nextPost.postId}`,
+        }
+      : null,
+  };
+
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'public, max-age=60, s-maxage=300',
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    },
+  });
+}

--- a/app/routes/api.search.tsx
+++ b/app/routes/api.search.tsx
@@ -1,0 +1,66 @@
+/**
+ * 検索API（外部公開）
+ * AIエージェント・スクレイパー等の外部利用向けに、検索結果をプレーンJSONで返す。
+ *
+ * GET /api/search?q=<keyword>&tags=<tag1>+<tag2>&orderby=<timeDesc|timeAsc|like>&page=<n>&pageSize=<n>
+ */
+import type { LoaderFunctionArgs } from 'react-router';
+import { searchPosts } from '~/modules/db.server';
+import type { SearchOrderBy } from '~/modules/db.server';
+
+const PAGE_SIZE_DEFAULT = 10;
+const PAGE_SIZE_MAX = 50;
+
+const ORDER_BY_VALUES: SearchOrderBy[] = ['timeDesc', 'timeAsc', 'like'];
+
+function parseOrderBy(value: string | null): SearchOrderBy {
+  return ORDER_BY_VALUES.includes(value as SearchOrderBy) ? (value as SearchOrderBy) : 'timeDesc';
+}
+
+function clampPositiveInt(value: string | null, fallback: number, max?: number): number {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < 1) return fallback;
+  const intN = Math.floor(n);
+  return max !== undefined ? Math.min(intN, max) : intN;
+}
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const url = new URL(request.url);
+  const query = url.searchParams.get('q') ?? '';
+  const orderby = parseOrderBy(url.searchParams.get('orderby'));
+  const tags = url.searchParams.get('tags')?.split(/[\s+]/).filter(Boolean) ?? [];
+  const page = clampPositiveInt(url.searchParams.get('page'), 1);
+  const pageSize = clampPositiveInt(
+    url.searchParams.get('pageSize'),
+    PAGE_SIZE_DEFAULT,
+    PAGE_SIZE_MAX,
+  );
+
+  const result = await searchPosts(query, orderby, page, tags, pageSize);
+
+  const baseUrl = `${url.origin}/archives`;
+  const payload = {
+    metadata: result.metadata,
+    tagCounts: result.tagCounts,
+    results: result.results.map((post) => ({
+      postId: post.postId,
+      postTitle: post.postTitle,
+      postUrl: `${baseUrl}/${post.postId}`,
+      postDateGmt: post.postDateGmt.toISOString(),
+      countLikes: post.countLikes,
+      countDislikes: post.countDislikes,
+      countComments: post.countComments,
+      tagNames: post.tagNames,
+    })),
+  };
+
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'public, max-age=60, s-maxage=300',
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    },
+  });
+}


### PR DESCRIPTION
## Summary

- 外部AIエージェント向けに公開JSON API 2本を新設した
  - `GET /api/search` — キーワード・タグで投稿一覧（メタデータ）を検索
  - `GET /api/posts/:postId` — 個別投稿の本文・コメント・タグ・関連投稿を取得
- 既存の `searchPosts()` / `ArchiveDataEntry.getData()` をそのまま再利用
- READMEのサイト説明に「AIから健常者エミュレータ事例集を検索する方法」セクションを追加し、FAQからも誘導

## 背景

`/search` や記事ページのloaderデータは React Router の Turbo Stream 形式 (`text/x-script`) で返されるため、外部からプログラム的に扱うのが難しい。
AIエージェントから検索結果や本文を構造化データとして取得したいユースケースに応えるため、薄いJSONラッパー2本を切り出した。

## 仕様

### 検索API

```
GET /api/search?q=<keyword>&tags=<tag1>+<tag2>&orderby=<timeDesc|timeAsc|like>&page=<n>&pageSize=<n>
```

- `pageSize` は最大50でクランプ
- 各投稿に絶対URL (`postUrl`) を付与
- レスポンス: `metadata`, `tagCounts`, `results[]`

### 本文取得API

```
GET /api/posts/:postId
```

- `postId` が不正なら400、該当投稿なしなら404
- レスポンス: タイトル・本文HTML・コメント・タグ・類似投稿（Vectorize）・前後投稿・各種カウント

### 共通

- 認証不要・CORS対応（`Access-Control-Allow-Origin: *`）
- `Cache-Control: public, max-age=60, s-maxage=300` でCloudflare側キャッシュ

## Test plan

- [x] Preview環境にデプロイされたら `/api/search?q=挨拶&pageSize=3` でJSONが返ることを確認
- [x] `/api/search?tags=コミュニケーション&orderby=like` でタグ絞り込み＋並び順切替を確認
- [x] `/api/search` （クエリなし）でも200が返ることを確認
- [x] `/api/posts/<existingId>` で本文HTML・タグ・コメント・前後投稿を取得できることを確認
- [x] `/api/posts/abc` `/api/posts/-1` で400、`/api/posts/99999999` で404を確認
- [x] `/readme#ai-search` に説明セクションが表示されることを確認
- [x] FAQに「AIから健常者エミュレータ事例集を検索できますか？」項目が追加されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)