### PR TITLE
feat: AIエージェント対応 (Markdown negotiation + Agent Skills index)

### DIFF
--- a/app/modules/agent-skills.server.ts
+++ b/app/modules/agent-skills.server.ts
@@ -1,0 +1,81 @@
+export const SKILL_NAME = 'healthy-person-emulator';
+export const SKILL_DESCRIPTION =
+  '健常者エミュレータ事例集 (healthy-person-emulator.org) — ユーザー投稿型の社会的暗黙知ナレッジベース。事例の検索・閲覧、Markdown版記事の取得、最新フィード参照のためのエンドポイント一覧を提供する。';
+export const SKILL_URL =
+  'https://healthy-person-emulator.org/.well-known/agent-skills/healthy-person-emulator/SKILL.md';
+
+export const SKILL_MD = `---
+name: ${SKILL_NAME}
+description: ${SKILL_DESCRIPTION}
+---
+
+# 健常者エミュレータ事例集 — Skill
+
+このスキルを使うと、AIエージェントは healthy-person-emulator.org (ユーザー投稿型の社会的暗黙知ナレッジベース) のコンテンツを取得できる。
+
+## このサイトについて
+
+- 全コンテンツは日本語。
+- 各記事は1件の事例。状況・失敗・教訓・推奨行動・タグ・投票・コメントを含む。
+- 認証なしで全コンテンツを読める。
+
+## 利用可能なエンドポイント
+
+### 検索
+- HTML: \`GET https://healthy-person-emulator.org/search?q={query}\`
+- JSON (推奨): \`GET https://healthy-person-emulator.org/api/search?q={query}\`
+
+JSON版はAIエージェント・スクレイパー向けに整形済み。
+
+### 最新記事フィード
+\`GET https://healthy-person-emulator.org/feed.xml\`
+
+### サイトマップ
+\`GET https://healthy-person-emulator.org/sitemap.xml\` — 全記事URLを列挙したXML。
+
+### 記事本文の取得
+- HTML: \`GET https://healthy-person-emulator.org/archives/{postId}\`
+- Markdown (URL指定): \`GET https://healthy-person-emulator.org/archives/{postId}.md\`
+- Markdown (Acceptヘッダ): \`GET https://healthy-person-emulator.org/archives/{postId}\` with \`Accept: text/markdown\`
+
+Markdown版はタイトル/投稿日/タグ/いいね数/本文/コメント/類似記事を構造化した形式で返す。
+
+### サイトトップ (一覧)
+- HTML: \`GET https://healthy-person-emulator.org/\`
+- Markdown: 上記URLに \`Accept: text/markdown\` を付与すると、最新および人気の投稿一覧をMarkdownで取得できる。
+
+## 引用と帰属
+
+要約や引用時は、必ず元の記事URL \`https://healthy-person-emulator.org/archives/{postId}\` をリンクすること。読者が原文と全文脈にアクセスできる状態を保つ。
+
+## 注意事項
+
+- \`is_welcomed=false\` と判定されている記事は、コミュニティが「歓迎されない行動」として記録したもの。要約時は同等の文脈情報を含めること。
+- 個人を特定するような言及や、特定アカウントの詳細な引用は避ける。
+`;
+
+async function sha256Hex(input: string): Promise<string> {
+  const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export async function getSkillDigest(): Promise<string> {
+  return `sha256:${await sha256Hex(SKILL_MD)}`;
+}
+
+export async function getSkillsIndex() {
+  return {
+    $schema: 'https://schemas.agentskills.io/discovery/0.2.0/schema.json',
+    skills: [
+      {
+        name: SKILL_NAME,
+        type: 'skill-md',
+        description: SKILL_DESCRIPTION,
+        url: SKILL_URL,
+        digest: await getSkillDigest(),
+      },
+    ],
+  };
+}

--- a/app/modules/markdown.server.ts
+++ b/app/modules/markdown.server.ts
@@ -1,0 +1,22 @@
+import { NodeHtmlMarkdown } from 'node-html-markdown';
+
+const converter = new NodeHtmlMarkdown();
+
+export function htmlToMarkdown(html: string): string {
+  return converter.translate(html);
+}
+
+export function wantsMarkdown(request: Request): boolean {
+  const accept = request.headers.get('accept') ?? '';
+  return /\btext\/markdown\b/i.test(accept);
+}
+
+export function markdownResponse(body: string, cacheMaxAgeSec = 300): Response {
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': `public, max-age=${cacheMaxAgeSec}`,
+      Vary: 'Accept',
+    },
+  });
+}

--- a/app/modules/markdown.server.ts
+++ b/app/modules/markdown.server.ts
@@ -1,9 +1,61 @@
 import { NodeHtmlMarkdown } from 'node-html-markdown';
+import type { ArchiveDataEntry } from '~/modules/db.server';
 
 const converter = new NodeHtmlMarkdown();
 
 export function htmlToMarkdown(html: string): string {
   return converter.translate(html);
+}
+
+export function renderArticleMarkdown(data: ArchiveDataEntry): string {
+  const lines: string[] = [];
+  const canonicalUrl = `https://healthy-person-emulator.org/archives/${data.postId}`;
+  lines.push(`# ${data.postTitle}`);
+  lines.push('');
+  lines.push(`- URL: ${canonicalUrl}`);
+  lines.push(`- 投稿日 (UTC): ${new Date(data.postDateGmt).toISOString()}`);
+  lines.push(`- 👍 いいね: ${data.countLikes}`);
+  lines.push(`- 👎 よくないね: ${data.countDislikes}`);
+  lines.push(`- 🔖 ブックマーク: ${data.countBookmarks}`);
+  if (data.tags.length > 0) {
+    lines.push(`- タグ: ${data.tags.map((t) => t.tagName).join(', ')}`);
+  }
+  if (data.isWelcomed === false) {
+    lines.push('- ⚠️ コミュニティ判定: 歓迎されない行動として記録されています');
+    if (data.isWelcomedExplanation) {
+      lines.push(`  - 理由: ${data.isWelcomedExplanation}`);
+    }
+  }
+  lines.push('');
+  lines.push('## 本文');
+  lines.push('');
+  lines.push(htmlToMarkdown(data.postContent));
+  lines.push('');
+
+  if (data.comments.length > 0) {
+    lines.push('## コメント');
+    lines.push('');
+    for (const c of data.comments) {
+      const date = new Date(c.commentDateGmt).toISOString();
+      lines.push(`### ${c.commentAuthor} — ${date}`);
+      lines.push('');
+      lines.push(`👍 ${c.likesCount} / 👎 ${c.dislikesCount}`);
+      lines.push('');
+      lines.push(htmlToMarkdown(c.commentContent));
+      lines.push('');
+    }
+  }
+
+  if (data.similarPosts.length > 0) {
+    lines.push('## 類似記事');
+    lines.push('');
+    for (const p of data.similarPosts) {
+      lines.push(`- [${p.postTitle}](https://healthy-person-emulator.org/archives/${p.postId})`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
 }
 
 export function wantsMarkdown(request: Request): boolean {

--- a/app/routes/[.]well-known.agent-skills.healthy-person-emulator.SKILL[.]md.tsx
+++ b/app/routes/[.]well-known.agent-skills.healthy-person-emulator.SKILL[.]md.tsx
@@ -1,0 +1,10 @@
+import { SKILL_MD } from '~/modules/agent-skills.server';
+
+export function loader() {
+  return new Response(SKILL_MD, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+}

--- a/app/routes/[.]well-known.agent-skills.index[.]json.tsx
+++ b/app/routes/[.]well-known.agent-skills.index[.]json.tsx
@@ -1,0 +1,11 @@
+import { getSkillsIndex } from '~/modules/agent-skills.server';
+
+export async function loader() {
+  const index = await getSkillsIndex();
+  return new Response(JSON.stringify(index, null, 2), {
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+}

--- a/app/routes/_layout._index.tsx
+++ b/app/routes/_layout._index.tsx
@@ -11,6 +11,45 @@ import ReloadButton from '~/components/ReloadButton';
 import PostSection from '~/components/PostSection';
 import CommentSection from '~/components/CommentSection';
 import { commonMetaFunction } from '~/utils/commonMetafunction';
+import { markdownResponse, wantsMarkdown } from '~/modules/markdown.server';
+
+function renderHomeMarkdown(data: {
+  latest: { postId: number; postTitle: string; postDateGmt: Date }[];
+  voted: { postId: number; postTitle: string; countLikes: number }[];
+}): string {
+  const lines: string[] = [];
+  lines.push('# 健常者エミュレータ事例集');
+  lines.push('');
+  lines.push(
+    '社会生活やコミュニケーションに関する暗黙知を言語化・集積し、知識のギャップを集団で補うためのプラットフォーム。',
+  );
+  lines.push('');
+  lines.push('- サイト: https://healthy-person-emulator.org');
+  lines.push('- フィード: https://healthy-person-emulator.org/feed.xml');
+  lines.push('- サイトマップ: https://healthy-person-emulator.org/sitemap.xml');
+  lines.push(
+    '- 各記事のMarkdown版: `https://healthy-person-emulator.org/archives/{postId}.md` または `Accept: text/markdown` ヘッダー付きで記事URLにリクエスト',
+  );
+  lines.push('');
+  lines.push('## 最新の投稿');
+  lines.push('');
+  for (const p of data.latest) {
+    const date = new Date(p.postDateGmt).toISOString().slice(0, 10);
+    lines.push(
+      `- [${p.postTitle}](https://healthy-person-emulator.org/archives/${p.postId}) — ${date}`,
+    );
+  }
+  lines.push('');
+  lines.push('## 最近いいねされた投稿');
+  lines.push('');
+  for (const p of data.voted) {
+    lines.push(
+      `- [${p.postTitle}](https://healthy-person-emulator.org/archives/${p.postId}) — 👍 ${p.countLikes}`,
+    );
+  }
+  lines.push('');
+  return lines.join('\n');
+}
 
 export const meta: MetaFunction = () => {
   const commonMeta = commonMetaFunction({
@@ -32,6 +71,16 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const mostRecentComments = await getFeedComments(1, 'timeDesc');
   const randomPosts = await getRandomPosts();
   const randomComments = await getRandomComments();
+
+  if (wantsMarkdown(request)) {
+    throw markdownResponse(
+      renderHomeMarkdown({
+        latest: mostRecentPosts.result,
+        voted: recentVotedPosts.result,
+      }),
+    );
+  }
+
   return {
     tab,
     mostRecentPosts,

--- a/app/routes/_layout.archives.$postId.tsx
+++ b/app/routes/_layout.archives.$postId.tsx
@@ -46,6 +46,7 @@ import { setIsLoginModalOpenAtom } from '~/stores/loginmodal';
 import { useSetAtom } from 'jotai';
 import { setVisitorCookieData } from '~/modules/visitor.server';
 import { Bookmark } from 'lucide-react';
+import { markdownResponse, renderArticleMarkdown, wantsMarkdown } from '~/modules/markdown.server';
 
 export const commentVoteSchema = z.object({
   commentId: z.number(),
@@ -62,6 +63,11 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const url = new URL(request.url);
   const postId = Number(url.pathname.split('/')[2]);
   const data = await ArchiveDataEntry.getData(postId);
+
+  if (wantsMarkdown(request)) {
+    throw markdownResponse(renderArticleMarkdown(data));
+  }
+
   const { likedPages, dislikedPages, likedComments, dislikedComments } =
     await getUserActivityData(request);
   const isAuthenticated = await getAuthenticatedUser(request);

--- a/app/routes/archives.$postId[.]md.tsx
+++ b/app/routes/archives.$postId[.]md.tsx
@@ -1,0 +1,12 @@
+import type { LoaderFunctionArgs } from 'react-router';
+import { ArchiveDataEntry } from '~/modules/db.server';
+import { markdownResponse, renderArticleMarkdown } from '~/modules/markdown.server';
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  const postId = Number(params.postId);
+  if (!Number.isFinite(postId) || postId <= 0) {
+    return new Response('Not Found', { status: 404 });
+  }
+  const data = await ArchiveDataEntry.getData(postId);
+  return markdownResponse(renderArticleMarkdown(data));
+}

--- a/tests/modules/agent-skills.server.test.ts
+++ b/tests/modules/agent-skills.server.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SKILL_MD,
+  SKILL_NAME,
+  SKILL_URL,
+  getSkillDigest,
+  getSkillsIndex,
+} from '~/modules/agent-skills.server';
+
+describe('agent-skills', () => {
+  it('SKILL_MD starts with YAML frontmatter containing name and description', () => {
+    expect(SKILL_MD.startsWith('---\n')).toBe(true);
+    expect(SKILL_MD).toMatch(/^---\nname: healthy-person-emulator\ndescription: .+\n---/);
+  });
+
+  it('digest is sha256-prefixed 64-char lowercase hex matching SKILL_MD', async () => {
+    const digest = await getSkillDigest();
+    expect(digest).toMatch(/^sha256:[0-9a-f]{64}$/);
+
+    const expected = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(SKILL_MD));
+    const hex = Array.from(new Uint8Array(expected))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+    expect(digest).toBe(`sha256:${hex}`);
+  });
+
+  it('skills index conforms to v0.2.0 schema shape', async () => {
+    const index = await getSkillsIndex();
+    expect(index.$schema).toBe('https://schemas.agentskills.io/discovery/0.2.0/schema.json');
+    expect(index.skills).toHaveLength(1);
+
+    const skill = index.skills[0];
+    expect(skill.name).toBe(SKILL_NAME);
+    expect(skill.type).toBe('skill-md');
+    expect(skill.url).toBe(SKILL_URL);
+    expect(skill.description.length).toBeLessThanOrEqual(1024);
+    expect(skill.digest).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+});


### PR DESCRIPTION
## Summary

[isitagentready.com](https://isitagentready.com/healthy-person-emulator.org) のスキャンで未対応扱いだった項目のうち、サイトの性質に合致する「Easy Wins」3点を実装した。

- **トップページのMarkdown content negotiation**: `Accept: text/markdown` 付きリクエストでサイト概要と最新/人気投稿一覧をMarkdownで返す
- **記事ページのMarkdown content negotiation + `.md` URL**: `Accept: text/markdown` ヘッダー、または `/archives/{postId}.md` URL で記事をMarkdown形式 (タイトル/投稿日/タグ/いいね数/本文/コメント/類似記事) で返す
- **`/.well-known/agent-skills/`**: v0.2.0 スキーマ準拠の `index.json` と、サイトの利用方法・エンドポイント一覧・引用ルールを記述した `SKILL.md` を配信。digestはSKILL.mdからSHA-256で動的算出

## なぜ

AIエージェントが本サイトのコンテンツ構造とアクセス方法を低コストで把握できるようにする。HTMLパースを経由しないMarkdown経路を提供することで、要約・検索・引用の品質向上を狙う。

## スコープ外と判断した項目

- Link headers — ヘッダー操作の追加対応が必要、効果に対してコストが見合わない
- OAuth/MCP server/A2A/WebMCP — 認証付きエージェント連携を提供する予定がないため不要
- Commerce系 (x402/MPP/UCP/ACP/AP2) — コマースサイトではないため対象外
- Content Signals — 別ブランチで議論あり、本PRでは扱わない

## Test plan

- [x] `pnpm build` 成功
- [x] `pnpm test tests/modules/agent-skills.server.test.ts` 3件pass (SKILL.md frontmatter, digest算出, index schema)
- [x] route型生成で `/.well-known/agent-skills/{index.json, healthy-person-emulator/SKILL.md}` と `/archives/:postId.md` を確認
- [ ] デプロイ後 isitagentready.com で再スキャンし、markdown negotiation と agent-skills が pass になることを確認
- [ ] `curl -H "Accept: text/markdown" https://healthy-person-emulator.org/` でMarkdown応答を確認
- [ ] `curl https://healthy-person-emulator.org/archives/{任意ID}.md` でMarkdown応答を確認
- [ ] `curl https://healthy-person-emulator.org/.well-known/agent-skills/index.json | jq` でindex取得を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)