### PR TITLE
fix: Markdownコンテンツネゴシエーションをworker層リライトで実装し直す

### DIFF
--- a/app/modules/markdown.server.ts
+++ b/app/modules/markdown.server.ts
@@ -58,9 +58,42 @@ export function renderArticleMarkdown(data: ArchiveDataEntry): string {
   return lines.join('\n');
 }
 
-export function wantsMarkdown(request: Request): boolean {
-  const accept = request.headers.get('accept') ?? '';
-  return /\btext\/markdown\b/i.test(accept);
+export function renderHomeMarkdown(data: {
+  latest: { postId: number; postTitle: string; postDateGmt: Date }[];
+  voted: { postId: number; postTitle: string; countLikes: number }[];
+}): string {
+  const lines: string[] = [];
+  lines.push('# 健常者エミュレータ事例集');
+  lines.push('');
+  lines.push(
+    '社会生活やコミュニケーションに関する暗黙知を言語化・集積し、知識のギャップを集団で補うためのプラットフォーム。',
+  );
+  lines.push('');
+  lines.push('- サイト: https://healthy-person-emulator.org');
+  lines.push('- フィード: https://healthy-person-emulator.org/feed.xml');
+  lines.push('- サイトマップ: https://healthy-person-emulator.org/sitemap.xml');
+  lines.push(
+    '- 各記事のMarkdown版: `https://healthy-person-emulator.org/archives/{postId}.md` または `Accept: text/markdown` ヘッダー付きで記事URLにリクエスト',
+  );
+  lines.push('');
+  lines.push('## 最新の投稿');
+  lines.push('');
+  for (const p of data.latest) {
+    const date = new Date(p.postDateGmt).toISOString().slice(0, 10);
+    lines.push(
+      `- [${p.postTitle}](https://healthy-person-emulator.org/archives/${p.postId}) — ${date}`,
+    );
+  }
+  lines.push('');
+  lines.push('## 最近いいねされた投稿');
+  lines.push('');
+  for (const p of data.voted) {
+    lines.push(
+      `- [${p.postTitle}](https://healthy-person-emulator.org/archives/${p.postId}) — 👍 ${p.countLikes}`,
+    );
+  }
+  lines.push('');
+  return lines.join('\n');
 }
 
 export function markdownResponse(body: string, cacheMaxAgeSec = 300): Response {

--- a/app/routes/_layout._index.tsx
+++ b/app/routes/_layout._index.tsx
@@ -11,45 +11,6 @@ import ReloadButton from '~/components/ReloadButton';
 import PostSection from '~/components/PostSection';
 import CommentSection from '~/components/CommentSection';
 import { commonMetaFunction } from '~/utils/commonMetafunction';
-import { markdownResponse, wantsMarkdown } from '~/modules/markdown.server';
-
-function renderHomeMarkdown(data: {
-  latest: { postId: number; postTitle: string; postDateGmt: Date }[];
-  voted: { postId: number; postTitle: string; countLikes: number }[];
-}): string {
-  const lines: string[] = [];
-  lines.push('# 健常者エミュレータ事例集');
-  lines.push('');
-  lines.push(
-    '社会生活やコミュニケーションに関する暗黙知を言語化・集積し、知識のギャップを集団で補うためのプラットフォーム。',
-  );
-  lines.push('');
-  lines.push('- サイト: https://healthy-person-emulator.org');
-  lines.push('- フィード: https://healthy-person-emulator.org/feed.xml');
-  lines.push('- サイトマップ: https://healthy-person-emulator.org/sitemap.xml');
-  lines.push(
-    '- 各記事のMarkdown版: `https://healthy-person-emulator.org/archives/{postId}.md` または `Accept: text/markdown` ヘッダー付きで記事URLにリクエスト',
-  );
-  lines.push('');
-  lines.push('## 最新の投稿');
-  lines.push('');
-  for (const p of data.latest) {
-    const date = new Date(p.postDateGmt).toISOString().slice(0, 10);
-    lines.push(
-      `- [${p.postTitle}](https://healthy-person-emulator.org/archives/${p.postId}) — ${date}`,
-    );
-  }
-  lines.push('');
-  lines.push('## 最近いいねされた投稿');
-  lines.push('');
-  for (const p of data.voted) {
-    lines.push(
-      `- [${p.postTitle}](https://healthy-person-emulator.org/archives/${p.postId}) — 👍 ${p.countLikes}`,
-    );
-  }
-  lines.push('');
-  return lines.join('\n');
-}
 
 export const meta: MetaFunction = () => {
   const commonMeta = commonMetaFunction({
@@ -71,15 +32,6 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const mostRecentComments = await getFeedComments(1, 'timeDesc');
   const randomPosts = await getRandomPosts();
   const randomComments = await getRandomComments();
-
-  if (wantsMarkdown(request)) {
-    throw markdownResponse(
-      renderHomeMarkdown({
-        latest: mostRecentPosts.result,
-        voted: recentVotedPosts.result,
-      }),
-    );
-  }
 
   return {
     tab,

--- a/app/routes/_layout.archives.$postId.tsx
+++ b/app/routes/_layout.archives.$postId.tsx
@@ -46,7 +46,6 @@ import { setIsLoginModalOpenAtom } from '~/stores/loginmodal';
 import { useSetAtom } from 'jotai';
 import { setVisitorCookieData } from '~/modules/visitor.server';
 import { Bookmark } from 'lucide-react';
-import { markdownResponse, renderArticleMarkdown, wantsMarkdown } from '~/modules/markdown.server';
 
 export const commentVoteSchema = z.object({
   commentId: z.number(),
@@ -63,11 +62,6 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const url = new URL(request.url);
   const postId = Number(url.pathname.split('/')[2]);
   const data = await ArchiveDataEntry.getData(postId);
-
-  if (wantsMarkdown(request)) {
-    throw markdownResponse(renderArticleMarkdown(data));
-  }
-
   const { likedPages, dislikedPages, likedComments, dislikedComments } =
     await getUserActivityData(request);
   const isAuthenticated = await getAuthenticatedUser(request);

--- a/app/routes/index[.]md.tsx
+++ b/app/routes/index[.]md.tsx
@@ -1,0 +1,13 @@
+import { getFeedPosts } from '~/modules/db.server';
+import { markdownResponse, renderHomeMarkdown } from '~/modules/markdown.server';
+
+export async function loader() {
+  const latest = await getFeedPosts(1, 'timeDesc', 12);
+  const voted = await getFeedPosts(1, 'likes', 12, 24, 0);
+  return markdownResponse(
+    renderHomeMarkdown({
+      latest: latest.result,
+      voted: voted.result,
+    }),
+  );
+}

--- a/worker.ts
+++ b/worker.ts
@@ -16,6 +16,24 @@ import resvgWasm from '@resvg/resvg-wasm/index_bg.wasm';
 
 const requestHandler = createRequestHandler(serverBuild as unknown as ServerBuild);
 
+function rewriteForMarkdown(request: Request): Request {
+  if (request.method !== 'GET') return request;
+  const accept = request.headers.get('accept') ?? '';
+  if (!/\btext\/markdown\b/i.test(accept)) return request;
+
+  const url = new URL(request.url);
+  if (url.pathname === '/') {
+    url.pathname = '/index.md';
+    return new Request(url.toString(), request);
+  }
+  const article = url.pathname.match(/^\/archives\/(\d+)\/?$/);
+  if (article) {
+    url.pathname = `/archives/${article[1]}.md`;
+    return new Request(url.toString(), request);
+  }
+  return request;
+}
+
 export default {
   async fetch(request: Request, env: CloudflareEnv, ctx: ExecutionContext) {
     (globalThis as any).__cloudflareEnv = env;
@@ -31,7 +49,7 @@ export default {
         caches,
       },
     };
-    return requestHandler(request, loadContext);
+    return requestHandler(rewriteForMarkdown(request), loadContext);
   },
 
   async scheduled(controller: ScheduledController, env: CloudflareEnv, ctx: ExecutionContext) {


### PR DESCRIPTION
## Summary

直前のPR #358 で Accept ヘッダーベースのMarkdownコンテンツネゴシエーションを `loader` 内の `throw new Response(...)` で実装したが、React Router v7 のUIルートでは2xx Responseのthrowが期待通りに動かず、isitagentready.com の再スキャンでも markdown negotiation は依然 fail のままだった。

worker.ts レベルで `Accept: text/markdown` 付きリクエストを `.md` リソースルート (`/index.md`, `/archives/{id}.md`) へ内部リライトする方式に変更した。

- `worker.ts`: `rewriteForMarkdown` で `/` と `/archives/{id}` を `.md` URLへ書き換え
- `app/routes/index[.]md.tsx`: ホームページ用リソースルートを新設
- `app/modules/markdown.server.ts`: `renderHomeMarkdown` をモジュールへ移動して両ルートで共有
- `_layout._index.tsx` / `_layout.archives.$postId.tsx`: 効いていない Accept 判定を削除

## Test plan

- [x] `pnpm build` 成功
- [x] route型生成で `/index.md`, `/archives/:postId.md` 確認
- [ ] デプロイ後、`curl -I -H "Accept: text/markdown" https://healthy-person-emulator.org/` が `content-type: text/markdown` を返すこと
- [ ] `curl -I -H "Accept: text/markdown" https://healthy-person-emulator.org/archives/{ID}` が `content-type: text/markdown` を返すこと
- [ ] isitagentready.com 再スキャンで markdown negotiation が pass になること
- [ ] 通常のブラウザアクセス (Accept: text/html,…) では従来通りHTMLが返ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)