### PR TITLE
feat: API仕様ページ /api-docs を独立させOpenAPI 3.1.0準拠に書き直した

### DIFF
--- a/app/components/Headings.tsx
+++ b/app/components/Headings.tsx
@@ -9,3 +9,11 @@ export const H2: React.FC<{ children: React.ReactNode }> = ({ children }) => {
 export const H3: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   return <h3 className="text-2xl font-bold mt-10 mb-6">{children}</h3>;
 };
+
+export const H4: React.FC<{ children: React.ReactNode; id?: string }> = ({ children, id }) => {
+  return (
+    <h4 id={id} className="text-xl font-bold mt-8 mb-4">
+      {children}
+    </h4>
+  );
+};

--- a/app/modules/openapi-spec.ts
+++ b/app/modules/openapi-spec.ts
@@ -1,0 +1,405 @@
+/**
+ * 健常者エミュレータ事例集 公開API の OpenAPI 3.1.0 仕様。
+ * `/api/openapi.json` および `/api-docs` の単一情報源。
+ */
+
+const BASE_URL = 'https://healthy-person-emulator.org';
+
+export const openApiSpec = {
+  openapi: '3.1.0',
+  info: {
+    title: '健常者エミュレータ事例集 公開API',
+    version: '1.0.0',
+    description:
+      'AIエージェント・外部クライアント向けに、健常者エミュレータ事例集の投稿を検索・取得するためのJSON API。認証不要・CORS対応。',
+    contact: {
+      name: '管理人',
+      url: 'https://x.com/messages/compose?recipient_id=1249916069344473088',
+    },
+    license: {
+      name: 'GPL-3.0',
+      url: 'https://www.gnu.org/licenses/gpl-3.0.html',
+    },
+  },
+  servers: [
+    {
+      url: BASE_URL,
+      description: '本番環境',
+    },
+    {
+      url: 'https://preview.healthy-person-emulator.org',
+      description: 'プレビュー環境（PRごとに更新）',
+    },
+  ],
+  tags: [
+    { name: 'search', description: '投稿検索' },
+    { name: 'posts', description: '投稿本文取得' },
+  ],
+  paths: {
+    '/api/search': {
+      get: {
+        operationId: 'searchPosts',
+        tags: ['search'],
+        summary: '投稿を検索する',
+        description:
+          'キーワード・タグで投稿一覧（タイトル・メタデータ）を取得する。本文を取得するには、結果中の `postId` を `GET /api/posts/{postId}` に渡す。',
+        parameters: [
+          {
+            name: 'q',
+            in: 'query',
+            required: false,
+            description: '検索キーワード（記事タイトル・本文を部分一致検索）',
+            schema: { type: 'string', default: '' },
+            example: '挨拶',
+          },
+          {
+            name: 'tags',
+            in: 'query',
+            required: false,
+            description: 'タグ名をスペース区切りで指定。複数指定時はAND条件で絞り込まれる。',
+            schema: { type: 'string', default: '' },
+            example: 'コミュニケーション 対人関係',
+          },
+          {
+            name: 'orderby',
+            in: 'query',
+            required: false,
+            description: '並び順',
+            schema: {
+              type: 'string',
+              enum: ['timeDesc', 'timeAsc', 'like'],
+              default: 'timeDesc',
+            },
+            example: 'like',
+          },
+          {
+            name: 'page',
+            in: 'query',
+            required: false,
+            description: 'ページ番号（1始まり）',
+            schema: { type: 'integer', minimum: 1, default: 1 },
+            example: 1,
+          },
+          {
+            name: 'pageSize',
+            in: 'query',
+            required: false,
+            description: '1ページあたりの件数。50を超える指定は50にクランプされる。',
+            schema: { type: 'integer', minimum: 1, maximum: 50, default: 10 },
+            example: 10,
+          },
+        ],
+        responses: {
+          '200': {
+            description: '検索成功',
+            headers: {
+              'Cache-Control': {
+                description: 'ブラウザ60秒・CDN300秒のpublic cache',
+                schema: { type: 'string' },
+                example: 'public, max-age=60, s-maxage=300',
+              },
+            },
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/SearchResult' },
+                examples: {
+                  keywordSearch: {
+                    summary: 'キーワード検索',
+                    value: {
+                      metadata: {
+                        query: '挨拶',
+                        count: 90,
+                        page: 1,
+                        totalPages: 9,
+                        orderby: 'timeDesc',
+                        hasMore: true,
+                      },
+                      tagCounts: [
+                        { tagName: 'コミュニケーション', count: 26 },
+                        { tagName: '対人関係', count: 23 },
+                      ],
+                      results: [
+                        {
+                          postId: 32172,
+                          postTitle: '付き合いたい異性には自然に交際相手がいないか聞いてみると良い',
+                          postUrl: `${BASE_URL}/archives/32172`,
+                          postDateGmt: '2023-04-10T11:38:49.000Z',
+                          countLikes: 97,
+                          countDislikes: 2,
+                          countComments: 9,
+                          tagNames: ['恋愛', '対人関係', '人間関係'],
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/api/posts/{postId}': {
+      get: {
+        operationId: 'getPostById',
+        tags: ['posts'],
+        summary: '投稿の本文・コメント・タグ等を取得する',
+        description:
+          '個別投稿の本文（HTML）・コメント一覧・タグ・類似投稿（Cloudflare Vectorize ベース）・前後の投稿等を取得する。',
+        parameters: [
+          {
+            name: 'postId',
+            in: 'path',
+            required: true,
+            description: '投稿ID。正の整数。',
+            schema: { type: 'integer', minimum: 1 },
+            example: 32172,
+          },
+        ],
+        responses: {
+          '200': {
+            description: '取得成功',
+            headers: {
+              'Cache-Control': {
+                description: 'ブラウザ60秒・CDN300秒のpublic cache',
+                schema: { type: 'string' },
+                example: 'public, max-age=60, s-maxage=300',
+              },
+            },
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/Post' },
+              },
+            },
+          },
+          '400': {
+            description: '不正な `postId`（非整数・0以下など）',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/Error' },
+                example: { error: 'postId must be a positive integer' },
+              },
+            },
+          },
+          '404': {
+            description: '該当する投稿が存在しない',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/Error' },
+                example: { error: 'Post not found' },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      SearchResult: {
+        type: 'object',
+        required: ['metadata', 'tagCounts', 'results'],
+        properties: {
+          metadata: { $ref: '#/components/schemas/SearchMetadata' },
+          tagCounts: {
+            type: 'array',
+            description: '検索結果に含まれるタグごとの件数（タグ絞り込みの参考用）',
+            items: { $ref: '#/components/schemas/TagCount' },
+          },
+          results: {
+            type: 'array',
+            description: '投稿の配列',
+            items: { $ref: '#/components/schemas/SearchHit' },
+          },
+        },
+      },
+      SearchMetadata: {
+        type: 'object',
+        required: ['query', 'count', 'page', 'totalPages', 'orderby', 'hasMore'],
+        properties: {
+          query: { type: 'string', description: 'リクエストで指定された `q` の値' },
+          count: { type: 'integer', description: '総ヒット件数' },
+          page: { type: 'integer', description: '現在のページ番号（1始まり）' },
+          totalPages: { type: 'integer', description: '総ページ数' },
+          orderby: {
+            type: 'string',
+            enum: ['timeDesc', 'timeAsc', 'like'],
+            description: '適用された並び順',
+          },
+          hasMore: {
+            type: 'boolean',
+            description: '次ページが存在するか',
+          },
+        },
+      },
+      TagCount: {
+        type: 'object',
+        required: ['tagName', 'count'],
+        properties: {
+          tagName: { type: 'string' },
+          count: { type: 'integer' },
+        },
+      },
+      SearchHit: {
+        type: 'object',
+        required: [
+          'postId',
+          'postTitle',
+          'postUrl',
+          'postDateGmt',
+          'countLikes',
+          'countDislikes',
+          'countComments',
+          'tagNames',
+        ],
+        properties: {
+          postId: { type: 'integer', description: '投稿ID（本文取得APIに渡す値）' },
+          postTitle: { type: 'string', description: 'タイトル' },
+          postUrl: {
+            type: 'string',
+            format: 'uri',
+            description: '投稿の絶対URL',
+          },
+          postDateGmt: {
+            type: 'string',
+            format: 'date-time',
+            description: '投稿日時（ISO 8601, UTC）',
+          },
+          countLikes: { type: 'integer' },
+          countDislikes: { type: 'integer' },
+          countComments: { type: 'integer' },
+          tagNames: {
+            type: 'array',
+            items: { type: 'string' },
+            description: '紐づくタグ名',
+          },
+        },
+      },
+      Post: {
+        type: 'object',
+        required: [
+          'postId',
+          'postTitle',
+          'postUrl',
+          'postDateGmt',
+          'postContentHtml',
+          'commentStatus',
+          'countLikes',
+          'countDislikes',
+          'countBookmarks',
+          'countComments',
+          'ogpImageUrl',
+          'isWelcomed',
+          'isWelcomedExplanation',
+          'tags',
+          'comments',
+          'similarPosts',
+          'previousPost',
+          'nextPost',
+        ],
+        properties: {
+          postId: { type: 'integer' },
+          postTitle: { type: 'string' },
+          postUrl: { type: 'string', format: 'uri' },
+          postDateGmt: { type: 'string', format: 'date-time' },
+          postContentHtml: {
+            type: 'string',
+            description: '投稿本文（HTML形式。サイト上の表示と同じマークアップ）',
+          },
+          commentStatus: {
+            type: 'string',
+            description: 'コメント受付状態（例: `open`, `closed`）',
+          },
+          countLikes: { type: 'integer' },
+          countDislikes: { type: 'integer' },
+          countBookmarks: { type: 'integer' },
+          countComments: { type: 'integer' },
+          ogpImageUrl: {
+            type: ['string', 'null'],
+            format: 'uri',
+            description: 'OGP画像のURL。未生成の場合は `null`',
+          },
+          isWelcomed: {
+            type: ['boolean', 'null'],
+            description: '管理人による「歓迎判定」の結果。未判定なら `null`',
+          },
+          isWelcomedExplanation: {
+            type: ['string', 'null'],
+            description: '歓迎判定の理由。未判定なら `null`',
+          },
+          tags: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/Tag' },
+          },
+          comments: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/Comment' },
+          },
+          similarPosts: {
+            type: 'array',
+            description: 'Cloudflare Vectorize による類似投稿。投稿によっては空配列のことがある。',
+            items: { $ref: '#/components/schemas/PostSummary' },
+          },
+          previousPost: {
+            oneOf: [{ $ref: '#/components/schemas/PostSummary' }, { type: 'null' }],
+            description: '前の投稿。先頭の投稿の場合は `null`',
+          },
+          nextPost: {
+            oneOf: [{ $ref: '#/components/schemas/PostSummary' }, { type: 'null' }],
+            description: '次の投稿。末尾の投稿の場合は `null`',
+          },
+        },
+      },
+      Tag: {
+        type: 'object',
+        required: ['tagName', 'tagId'],
+        properties: {
+          tagName: { type: 'string' },
+          tagId: { type: 'integer' },
+        },
+      },
+      Comment: {
+        type: 'object',
+        required: [
+          'commentId',
+          'commentDateGmt',
+          'commentAuthor',
+          'commentContent',
+          'likesCount',
+          'dislikesCount',
+          'commentParent',
+        ],
+        properties: {
+          commentId: { type: 'integer' },
+          commentDateGmt: { type: 'string', format: 'date-time' },
+          commentAuthor: { type: 'string' },
+          commentContent: { type: 'string' },
+          likesCount: { type: 'integer' },
+          dislikesCount: { type: 'integer' },
+          commentParent: {
+            type: 'integer',
+            description: '親コメントID。トップレベルコメントは `0`',
+          },
+        },
+      },
+      PostSummary: {
+        type: 'object',
+        required: ['postId', 'postTitle', 'postUrl'],
+        properties: {
+          postId: { type: 'integer' },
+          postTitle: { type: 'string' },
+          postUrl: { type: 'string', format: 'uri' },
+        },
+      },
+      Error: {
+        type: 'object',
+        required: ['error'],
+        properties: {
+          error: { type: 'string', description: 'エラーメッセージ' },
+        },
+      },
+    },
+  },
+} as const;
+
+export type OpenApiSpec = typeof openApiSpec;

--- a/app/routes/_layout.api-docs.tsx
+++ b/app/routes/_layout.api-docs.tsx
@@ -1,0 +1,596 @@
+/**
+ * 公開API仕様ページ（OpenAPI 3.1.0 ベース）。
+ * 機械可読版は `/api/openapi.json` で取得可能。
+ */
+import type { MetaFunction } from 'react-router';
+import { NavLink } from 'react-router';
+import { H1, H2, H3, H4 } from '~/components/Headings';
+import { commonMetaFunction } from '~/utils/commonMetafunction';
+import { openApiSpec } from '~/modules/openapi-spec';
+
+const BASE_URL = 'https://healthy-person-emulator.org';
+
+function MethodBadge({ method }: { method: 'GET' | 'POST' | 'PUT' | 'DELETE' }) {
+  const colors: Record<typeof method, string> = {
+    GET: 'bg-green-600',
+    POST: 'bg-blue-600',
+    PUT: 'bg-amber-600',
+    DELETE: 'bg-red-600',
+  };
+  return (
+    <span
+      className={`inline-block px-2 py-0.5 text-xs font-bold text-white rounded ${colors[method]}`}
+    >
+      {method}
+    </span>
+  );
+}
+
+function StatusBadge({ status }: { status: '2xx' | '4xx' | '5xx' }) {
+  const colors: Record<typeof status, string> = {
+    '2xx': 'bg-green-600',
+    '4xx': 'bg-amber-600',
+    '5xx': 'bg-red-600',
+  };
+  return (
+    <span
+      className={`inline-block px-2 py-0.5 text-xs font-bold text-white rounded ${colors[status]}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+function ParamTable({
+  rows,
+}: {
+  rows: Array<{
+    name: string;
+    location: string;
+    type: string;
+    required: boolean;
+    defaultValue?: string;
+    constraint?: string;
+    description: string;
+  }>;
+}) {
+  return (
+    <div className="overflow-x-auto my-4">
+      <table className="table table-zebra w-full text-sm">
+        <thead>
+          <tr>
+            <th>名前</th>
+            <th>位置</th>
+            <th>型</th>
+            <th>必須</th>
+            <th>制約 / デフォルト</th>
+            <th>説明</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.name}>
+              <td>
+                <code>{r.name}</code>
+              </td>
+              <td>{r.location}</td>
+              <td>
+                <code>{r.type}</code>
+              </td>
+              <td>{r.required ? '必須' : '任意'}</td>
+              <td className="text-xs">
+                {r.constraint && <div>{r.constraint}</div>}
+                {r.defaultValue !== undefined && (
+                  <div>
+                    デフォルト: <code>{r.defaultValue}</code>
+                  </div>
+                )}
+              </td>
+              <td>{r.description}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function SchemaTable({
+  rows,
+}: {
+  rows: Array<{
+    field: string;
+    type: string;
+    nullable?: boolean;
+    description: string;
+  }>;
+}) {
+  return (
+    <div className="overflow-x-auto my-4">
+      <table className="table table-zebra w-full text-sm">
+        <thead>
+          <tr>
+            <th>フィールド</th>
+            <th>型</th>
+            <th>nullable</th>
+            <th>説明</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.field}>
+              <td>
+                <code>{r.field}</code>
+              </td>
+              <td>
+                <code>{r.type}</code>
+              </td>
+              <td>{r.nullable ? '✓' : ''}</td>
+              <td>{r.description}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function CodeBlock({ children }: { children: string }) {
+  return (
+    <pre className="bg-base-300 text-base-content p-4 rounded my-4 overflow-x-auto text-xs">
+      <code>{children}</code>
+    </pre>
+  );
+}
+
+export default function Component() {
+  const spec = openApiSpec;
+  return (
+    <div className="postContent">
+      <H1>公開API仕様</H1>
+
+      <p>
+        健常者エミュレータ事例集の投稿を、AIエージェント・外部クライアントから検索・取得するための公開API仕様です。
+        OpenAPI 3.1.0 準拠の機械可読版は{' '}
+        <a href="/api/openapi.json">
+          <code>/api/openapi.json</code>
+        </a>{' '}
+        から取得できます。
+      </p>
+
+      <H2>概要</H2>
+      <ul>
+        <li>
+          <strong>バージョン:</strong> <code>{spec.info.version}</code>
+        </li>
+        <li>
+          <strong>ベースURL:</strong> <code>{BASE_URL}</code>
+          （プレビュー環境は <code>https://preview.healthy-person-emulator.org</code>）
+        </li>
+        <li>
+          <strong>認証:</strong> 不要（全エンドポイント公開）
+        </li>
+        <li>
+          <strong>CORS:</strong> <code>Access-Control-Allow-Origin: *</code>
+          （ブラウザJSから直接呼び出し可能）
+        </li>
+        <li>
+          <strong>レスポンス形式:</strong> <code>application/json; charset=utf-8</code>
+        </li>
+        <li>
+          <strong>キャッシュ:</strong> <code>Cache-Control: public, max-age=60, s-maxage=300</code>
+          （CloudflareのCDNで5分キャッシュ）
+        </li>
+        <li>
+          <strong>ライセンス:</strong> 投稿データは
+          <a href="https://www.gnu.org/licenses/gpl-3.0.html">GPL-3.0</a>
+          。利用時は <code>healthy-person-emulator.org</code> を出典として明示してください。
+        </li>
+      </ul>
+
+      <H3>レート制限</H3>
+      <p>
+        明示的なレート制限はありませんが、Cloudflareにより異常なリクエストパターンは制限される可能性があります。
+        AIエージェントから大量に取得する場合は、<code>postId</code>{' '}
+        ごとに数十ミリ秒の間隔を空けるなど、節度を持って利用してください。
+      </p>
+
+      <H3>共通エラーレスポンス</H3>
+      <p>4xx系のエラーは全て以下の形式のJSONで返却されます。</p>
+      <SchemaTable rows={[{ field: 'error', type: 'string', description: 'エラーメッセージ' }]} />
+
+      <H2>エンドポイント一覧</H2>
+      <ul>
+        <li>
+          <a href="#endpoint-search">
+            <MethodBadge method="GET" /> <code>/api/search</code> — 投稿を検索する
+          </a>
+        </li>
+        <li>
+          <a href="#endpoint-post">
+            <MethodBadge method="GET" /> <code>/api/posts/{'{postId}'}</code> —
+            投稿の本文・コメント・タグ等を取得する
+          </a>
+        </li>
+        <li>
+          <a href="#endpoint-openapi">
+            <MethodBadge method="GET" /> <code>/api/openapi.json</code> — OpenAPI 3.1.0 仕様
+          </a>
+        </li>
+      </ul>
+
+      <div id="endpoint-search">
+        <H2>
+          <MethodBadge method="GET" /> /api/search
+        </H2>
+        <p>キーワード・タグで投稿一覧（タイトル・メタデータ）を取得します。</p>
+        <p>
+          本文を取得するには、結果中の <code>postId</code> を{' '}
+          <a href="#endpoint-post">
+            <code>GET /api/posts/{'{postId}'}</code>
+          </a>{' '}
+          に渡してください。
+        </p>
+
+        <H3>リクエスト</H3>
+        <H4>クエリパラメータ</H4>
+        <ParamTable
+          rows={[
+            {
+              name: 'q',
+              location: 'query',
+              type: 'string',
+              required: false,
+              defaultValue: '""',
+              description: '検索キーワード。記事タイトル・本文を部分一致検索する。',
+            },
+            {
+              name: 'tags',
+              location: 'query',
+              type: 'string',
+              required: false,
+              defaultValue: '""',
+              description: 'タグ名をスペース区切りで指定。複数指定時はAND条件で絞り込まれる。',
+            },
+            {
+              name: 'orderby',
+              location: 'query',
+              type: 'string',
+              required: false,
+              defaultValue: 'timeDesc',
+              constraint: 'enum: timeDesc / timeAsc / like',
+              description: '並び順。不正な値はデフォルトにフォールバック。',
+            },
+            {
+              name: 'page',
+              location: 'query',
+              type: 'integer',
+              required: false,
+              defaultValue: '1',
+              constraint: '最小: 1',
+              description: 'ページ番号（1始まり）。',
+            },
+            {
+              name: 'pageSize',
+              location: 'query',
+              type: 'integer',
+              required: false,
+              defaultValue: '10',
+              constraint: '最小: 1 / 最大: 50',
+              description: '1ページあたりの件数。50を超える指定は50にクランプ。',
+            },
+          ]}
+        />
+
+        <H4>リクエスト例</H4>
+        <CodeBlock>{`# キーワード検索
+curl "${BASE_URL}/api/search?q=挨拶&pageSize=5"
+
+# タグ絞り込み＋いいね順
+curl "${BASE_URL}/api/search?tags=コミュニケーション&orderby=like"
+
+# ページング
+curl "${BASE_URL}/api/search?q=会話&page=2&pageSize=20"`}</CodeBlock>
+
+        <H3>レスポンス</H3>
+        <H4>
+          <StatusBadge status="2xx" /> 200 OK
+        </H4>
+        <p>
+          <code>SearchResult</code> オブジェクト。
+        </p>
+        <SchemaTable
+          rows={[
+            {
+              field: 'metadata',
+              type: 'SearchMetadata',
+              description: 'リクエスト条件のエコーバック・件数・ページング情報',
+            },
+            {
+              field: 'tagCounts',
+              type: 'TagCount[]',
+              description:
+                '検索結果（フィルタなし版）に含まれるタグごとの件数。タグ絞り込みの参考用',
+            },
+            {
+              field: 'results',
+              type: 'SearchHit[]',
+              description: '投稿の配列',
+            },
+          ]}
+        />
+
+        <H4>レスポンス例</H4>
+        <CodeBlock>{`{
+  "metadata": {
+    "query": "挨拶",
+    "count": 90,
+    "page": 1,
+    "totalPages": 9,
+    "orderby": "timeDesc",
+    "hasMore": true
+  },
+  "tagCounts": [
+    { "tagName": "コミュニケーション", "count": 26 },
+    { "tagName": "対人関係", "count": 23 }
+  ],
+  "results": [
+    {
+      "postId": 32172,
+      "postTitle": "付き合いたい異性には自然に交際相手がいないか聞いてみると良い",
+      "postUrl": "${BASE_URL}/archives/32172",
+      "postDateGmt": "2023-04-10T11:38:49.000Z",
+      "countLikes": 97,
+      "countDislikes": 2,
+      "countComments": 9,
+      "tagNames": ["恋愛", "対人関係", "人間関係"]
+    }
+  ]
+}`}</CodeBlock>
+      </div>
+
+      <div id="endpoint-post">
+        <H2>
+          <MethodBadge method="GET" /> /api/posts/{'{postId}'}
+        </H2>
+        <p>
+          個別投稿の本文（HTML）・コメント一覧・タグ・類似投稿（Cloudflare Vectorize
+          ベース）・前後の投稿を取得します。
+        </p>
+
+        <H3>リクエスト</H3>
+        <H4>パスパラメータ</H4>
+        <ParamTable
+          rows={[
+            {
+              name: 'postId',
+              location: 'path',
+              type: 'integer',
+              required: true,
+              constraint: '最小: 1',
+              description: '投稿ID。正の整数。',
+            },
+          ]}
+        />
+
+        <H4>リクエスト例</H4>
+        <CodeBlock>{`curl "${BASE_URL}/api/posts/32172"`}</CodeBlock>
+
+        <H3>レスポンス</H3>
+        <H4>
+          <StatusBadge status="2xx" /> 200 OK
+        </H4>
+        <p>
+          <code>Post</code> オブジェクト。
+        </p>
+        <SchemaTable
+          rows={[
+            { field: 'postId', type: 'integer', description: '投稿ID' },
+            { field: 'postTitle', type: 'string', description: 'タイトル' },
+            { field: 'postUrl', type: 'string (uri)', description: '投稿の絶対URL' },
+            {
+              field: 'postDateGmt',
+              type: 'string (date-time)',
+              description: '投稿日時（ISO 8601, UTC）',
+            },
+            {
+              field: 'postContentHtml',
+              type: 'string',
+              description: '投稿本文（HTML形式。サイト上の表示と同じマークアップ）',
+            },
+            {
+              field: 'commentStatus',
+              type: 'string',
+              description: 'コメント受付状態（例: open, closed）',
+            },
+            { field: 'countLikes', type: 'integer', description: 'いいね数' },
+            { field: 'countDislikes', type: 'integer', description: '低評価数' },
+            { field: 'countBookmarks', type: 'integer', description: 'ブックマーク数' },
+            { field: 'countComments', type: 'integer', description: 'コメント数' },
+            {
+              field: 'ogpImageUrl',
+              type: 'string (uri)',
+              nullable: true,
+              description: 'OGP画像のURL。未生成の場合は null',
+            },
+            {
+              field: 'isWelcomed',
+              type: 'boolean',
+              nullable: true,
+              description: '管理人による「歓迎判定」の結果。未判定なら null',
+            },
+            {
+              field: 'isWelcomedExplanation',
+              type: 'string',
+              nullable: true,
+              description: '歓迎判定の理由。未判定なら null',
+            },
+            { field: 'tags', type: 'Tag[]', description: '紐づくタグ' },
+            { field: 'comments', type: 'Comment[]', description: 'コメント一覧' },
+            {
+              field: 'similarPosts',
+              type: 'PostSummary[]',
+              description: 'Cloudflare Vectorize による類似投稿。埋め込みがない投稿の場合は空配列',
+            },
+            {
+              field: 'previousPost',
+              type: 'PostSummary',
+              nullable: true,
+              description: '前の投稿。先頭なら null',
+            },
+            {
+              field: 'nextPost',
+              type: 'PostSummary',
+              nullable: true,
+              description: '次の投稿。末尾なら null',
+            },
+          ]}
+        />
+
+        <H4>
+          <StatusBadge status="4xx" /> 400 Bad Request
+        </H4>
+        <p>
+          <code>postId</code> が正の整数でない場合（非数値・0以下など）。
+        </p>
+        <CodeBlock>{`{ "error": "postId must be a positive integer" }`}</CodeBlock>
+
+        <H4>
+          <StatusBadge status="4xx" /> 404 Not Found
+        </H4>
+        <p>
+          該当する <code>postId</code> の投稿が存在しない場合。
+        </p>
+        <CodeBlock>{`{ "error": "Post not found" }`}</CodeBlock>
+      </div>
+
+      <div id="endpoint-openapi">
+        <H2>
+          <MethodBadge method="GET" /> /api/openapi.json
+        </H2>
+        <p>
+          本APIのOpenAPI 3.1.0 仕様を機械可読なJSONで返します。
+          コード生成ツール（openapi-generator、orval等）やAIエージェントから直接読み込めます。
+        </p>
+        <CodeBlock>{`curl "${BASE_URL}/api/openapi.json"`}</CodeBlock>
+      </div>
+
+      <H2 id="schemas">スキーマ定義</H2>
+      <p>各エンドポイントで再利用される型の定義です。</p>
+
+      <H3>SearchMetadata</H3>
+      <SchemaTable
+        rows={[
+          { field: 'query', type: 'string', description: 'リクエストの q の値' },
+          { field: 'count', type: 'integer', description: '総ヒット件数' },
+          { field: 'page', type: 'integer', description: '現在のページ番号（1始まり）' },
+          { field: 'totalPages', type: 'integer', description: '総ページ数' },
+          {
+            field: 'orderby',
+            type: 'enum (timeDesc / timeAsc / like)',
+            description: '適用された並び順',
+          },
+          { field: 'hasMore', type: 'boolean', description: '次ページが存在するか' },
+        ]}
+      />
+
+      <H3>TagCount</H3>
+      <SchemaTable
+        rows={[
+          { field: 'tagName', type: 'string', description: 'タグ名' },
+          { field: 'count', type: 'integer', description: '件数' },
+        ]}
+      />
+
+      <H3>SearchHit</H3>
+      <SchemaTable
+        rows={[
+          { field: 'postId', type: 'integer', description: '投稿ID' },
+          { field: 'postTitle', type: 'string', description: 'タイトル' },
+          { field: 'postUrl', type: 'string (uri)', description: '投稿の絶対URL' },
+          {
+            field: 'postDateGmt',
+            type: 'string (date-time)',
+            description: '投稿日時（ISO 8601, UTC）',
+          },
+          { field: 'countLikes', type: 'integer', description: 'いいね数' },
+          { field: 'countDislikes', type: 'integer', description: '低評価数' },
+          { field: 'countComments', type: 'integer', description: 'コメント数' },
+          { field: 'tagNames', type: 'string[]', description: '紐づくタグ名' },
+        ]}
+      />
+
+      <H3>Tag</H3>
+      <SchemaTable
+        rows={[
+          { field: 'tagName', type: 'string', description: 'タグ名' },
+          { field: 'tagId', type: 'integer', description: 'タグID' },
+        ]}
+      />
+
+      <H3>Comment</H3>
+      <SchemaTable
+        rows={[
+          { field: 'commentId', type: 'integer', description: 'コメントID' },
+          {
+            field: 'commentDateGmt',
+            type: 'string (date-time)',
+            description: 'コメント投稿日時（ISO 8601, UTC）',
+          },
+          { field: 'commentAuthor', type: 'string', description: '投稿者名' },
+          { field: 'commentContent', type: 'string', description: 'コメント本文' },
+          { field: 'likesCount', type: 'integer', description: 'いいね数' },
+          { field: 'dislikesCount', type: 'integer', description: '低評価数' },
+          {
+            field: 'commentParent',
+            type: 'integer',
+            description: '親コメントID（トップレベルは 0）',
+          },
+        ]}
+      />
+
+      <H3>PostSummary</H3>
+      <SchemaTable
+        rows={[
+          { field: 'postId', type: 'integer', description: '投稿ID' },
+          { field: 'postTitle', type: 'string', description: 'タイトル' },
+          { field: 'postUrl', type: 'string (uri)', description: '投稿の絶対URL' },
+        ]}
+      />
+
+      <H3>Error</H3>
+      <SchemaTable rows={[{ field: 'error', type: 'string', description: 'エラーメッセージ' }]} />
+
+      <H2>利用条件と問い合わせ</H2>
+      <ul>
+        <li>
+          投稿データは GPL-3.0
+          ライセンスで公開されています。人間・機械の両方が自由に利用できますが、出典として{' '}
+          <code>healthy-person-emulator.org</code> を明示してください。
+        </li>
+        <li>
+          仕様変更時は本ページと <code>/api/openapi.json</code> の両方を更新します。
+          破壊的変更を行う場合は事前にDiscord・XのDM等で告知します。
+        </li>
+        <li>
+          バグ報告・要望は <a href="https://discord.com/invite/sQehNGTnSg">Discord</a>
+          の「#エンジニアリング議論」チャンネル、または管理人の{' '}
+          <a href="https://x.com/messages/compose?recipient_id=1249916069344473088">XのDM</a>
+          まで。
+        </li>
+        <li>
+          サイト全体の概要は<NavLink to="/readme">サイト説明</NavLink>を参照してください。
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+export const meta: MetaFunction = () => {
+  return commonMetaFunction({
+    title: '公開API仕様',
+    description: 'AIエージェント・外部クライアント向けの公開JSON API仕様（OpenAPI 3.1.0準拠）',
+    url: `${BASE_URL}/api-docs`,
+    image: null,
+  });
+};

--- a/app/routes/_layout.api-docs.tsx
+++ b/app/routes/_layout.api-docs.tsx
@@ -12,10 +12,10 @@ const BASE_URL = 'https://healthy-person-emulator.org';
 
 function MethodBadge({ method }: { method: 'GET' | 'POST' | 'PUT' | 'DELETE' }) {
   const colors: Record<typeof method, string> = {
-    GET: 'bg-green-600',
-    POST: 'bg-blue-600',
-    PUT: 'bg-amber-600',
-    DELETE: 'bg-red-600',
+    GET: 'bg-green-800',
+    POST: 'bg-blue-800',
+    PUT: 'bg-amber-800',
+    DELETE: 'bg-red-800',
   };
   return (
     <span
@@ -28,9 +28,9 @@ function MethodBadge({ method }: { method: 'GET' | 'POST' | 'PUT' | 'DELETE' }) 
 
 function StatusBadge({ status }: { status: '2xx' | '4xx' | '5xx' }) {
   const colors: Record<typeof status, string> = {
-    '2xx': 'bg-green-600',
-    '4xx': 'bg-amber-600',
-    '5xx': 'bg-red-600',
+    '2xx': 'bg-green-800',
+    '4xx': 'bg-amber-800',
+    '5xx': 'bg-red-800',
   };
   return (
     <span

--- a/app/routes/_layout.readme.tsx
+++ b/app/routes/_layout.readme.tsx
@@ -74,7 +74,7 @@ const faqData: FAQItem[] = [
   {
     question: 'AIから健常者エミュレータ事例集を検索できますか？',
     answer:
-      'できます。公開JSON API `/api/search` を用意しています。詳細はサイト説明の[「AIから健常者エミュレータ事例集を検索する方法」](/readme#ai-search)をご覧ください。',
+      'できます。投稿検索API `/api/search` と本文取得API `/api/posts/:postId` を公開しています。詳細は[公開API仕様](/api-docs)を参照してください。',
   },
 ];
 
@@ -217,158 +217,16 @@ export default function Component() {
         <li>10分に一回の頻度で更新されます</li>
       </ul>
 
-      <div id="ai-search">
-        <H2>AIから健常者エミュレータ事例集を検索する方法</H2>
-        <p>
-          ChatGPT・Claude・Gemini
-          などのAIエージェントから、健常者エミュレータ事例集の投稿を検索・取得するためのJSON
-          APIを公開しています。スクレイピング不要で、検索結果や本文をそのまま構造化データとして取得できます。
-        </p>
-        <p>用意しているエンドポイントは2つです。</p>
-        <ul>
-          <li>
-            <code>GET /api/search</code> — キーワード・タグで投稿を検索する
-          </li>
-          <li>
-            <code>GET /api/posts/:postId</code> — 投稿IDから本文・コメント・タグなどを取得する
-          </li>
-        </ul>
-        <p>
-          どちらも認証不要・CORS対応・<code>Content-Type: application/json</code>。 ベースURLは{' '}
-          <code>https://healthy-person-emulator.org</code>。
-        </p>
-        <H3>検索API: GET /api/search</H3>
-        <p>キーワード・タグで投稿一覧（タイトル・メタデータ）を取得します。</p>
-        <p>クエリパラメータ:</p>
-        <ul>
-          <li>
-            <code>q</code>: 検索キーワード（記事タイトル・本文を部分一致検索）。省略可
-          </li>
-          <li>
-            <code>tags</code>: タグ名をスペース区切りで指定（例:{' '}
-            <code>tags=コミュニケーション 対人関係</code>
-            ）。複数指定時はAND条件。省略可
-          </li>
-          <li>
-            <code>orderby</code>: 並び順。
-            <code>timeDesc</code>（新着順・デフォルト） /<code>timeAsc</code>（古い順） /
-            <code>like</code>（いいね順）
-          </li>
-          <li>
-            <code>page</code>: ページ番号（1始まり、デフォルト1）
-          </li>
-          <li>
-            <code>pageSize</code>: 1ページの件数（デフォルト10、最大50）
-          </li>
-        </ul>
-        <p>使用例:</p>
-        <ul>
-          <li>
-            キーワード検索: <code>/api/search?q=挨拶&amp;pageSize=5</code>
-          </li>
-          <li>
-            タグ絞り込み＋いいね順:{' '}
-            <code>/api/search?tags=コミュニケーション&amp;orderby=like</code>
-          </li>
-          <li>
-            ページング: <code>/api/search?q=会話&amp;page=2&amp;pageSize=20</code>
-          </li>
-        </ul>
-        <p>レスポンスは以下3つのフィールドからなるJSONオブジェクトです。</p>
-        <ul>
-          <li>
-            <code>metadata</code>: 検索条件のエコーバック・総件数・総ページ数・次ページの有無
-          </li>
-          <li>
-            <code>tagCounts</code>: 検索結果に含まれるタグごとの件数（タグ絞り込みの参考用）
-          </li>
-          <li>
-            <code>results</code>: 投稿の配列。各要素は以下のフィールドを持ちます
-            <ul>
-              <li>
-                <code>postId</code>: 投稿ID（本文取得APIに渡す値）
-              </li>
-              <li>
-                <code>postTitle</code>: タイトル
-              </li>
-              <li>
-                <code>postUrl</code>: 投稿の絶対URL
-              </li>
-              <li>
-                <code>postDateGmt</code>: 投稿日時（ISO 8601, UTC）
-              </li>
-              <li>
-                <code>countLikes</code> / <code>countDislikes</code> / <code>countComments</code>:
-                各種カウント
-              </li>
-              <li>
-                <code>tagNames</code>: 紐づくタグ名の配列
-              </li>
-            </ul>
-          </li>
-        </ul>
-
-        <H3>本文取得API: GET /api/posts/:postId</H3>
-        <p>
-          検索APIで得た <code>postId</code>{' '}
-          を使い、個別投稿の本文・コメント・タグ・関連投稿等の詳細を取得します。
-        </p>
-        <p>パスパラメータ:</p>
-        <ul>
-          <li>
-            <code>postId</code>:
-            投稿ID（正の整数）。不正な値の場合は400、該当投稿が存在しない場合は404を返します
-          </li>
-        </ul>
-        <p>使用例:</p>
-        <ul>
-          <li>
-            <code>/api/posts/12345</code>
-          </li>
-        </ul>
-        <p>レスポンスは投稿の詳細を表すJSONオブジェクトです。主なフィールド:</p>
-        <ul>
-          <li>
-            <code>postTitle</code>: タイトル
-          </li>
-          <li>
-            <code>postContentHtml</code>: 投稿本文（HTML形式。サイト上の表示と同じマークアップ）
-          </li>
-          <li>
-            <code>postDateGmt</code>: 投稿日時（ISO 8601, UTC）
-          </li>
-          <li>
-            <code>tags</code>: 紐づくタグの配列（<code>tagName</code> / <code>tagId</code>）
-          </li>
-          <li>
-            <code>comments</code>: コメントの配列（投稿者名・本文・日時・親コメントID等）
-          </li>
-          <li>
-            <code>similarPosts</code>: 類似投稿の配列（Cloudflare Vectorize ベース）
-          </li>
-          <li>
-            <code>previousPost</code> / <code>nextPost</code>: 前後の投稿
-          </li>
-          <li>
-            <code>countLikes</code> / <code>countDislikes</code> / <code>countBookmarks</code> /{' '}
-            <code>countComments</code>: 各種カウント
-          </li>
-          <li>
-            <code>ogpImageUrl</code>: OGP画像URL
-          </li>
-        </ul>
-
-        <H3>注意事項</H3>
-        <ul>
-          <li>
-            短時間に過度なリクエストを送信した場合、Cloudflareにより制限される可能性があります
-          </li>
-          <li>
-            投稿データはGPL-3.0ライセンスの元、人間および機械の両方が自由に利用できますが、出典として{' '}
-            <code>healthy-person-emulator.org</code> を明示してください
-          </li>
-        </ul>
-      </div>
+      <H2>AIエージェント・外部からの利用</H2>
+      <ul>
+        <li>
+          投稿の検索・取得には公開JSON APIを利用できます。詳細は
+          <NavLink to="/api-docs">公開API仕様</NavLink>を参照してください。
+        </li>
+        <li>
+          機械可読なOpenAPI 3.1.0仕様は <code>/api/openapi.json</code> で取得できます。
+        </li>
+      </ul>
 
       <H2>開発について</H2>
       <ul>

--- a/app/routes/_layout.readme.tsx
+++ b/app/routes/_layout.readme.tsx
@@ -73,8 +73,7 @@ const faqData: FAQItem[] = [
   },
   {
     question: 'AIから健常者エミュレータ事例集を検索できますか？',
-    answer:
-      'できます。投稿検索API `/api/search` と本文取得API `/api/posts/:postId` を公開しています。詳細は[公開API仕様](/api-docs)を参照してください。',
+    answer: 'できます。詳細は[公開API仕様](/api-docs)を参照してください。',
   },
 ];
 

--- a/app/routes/api.openapi[.]json.tsx
+++ b/app/routes/api.openapi[.]json.tsx
@@ -1,0 +1,17 @@
+/**
+ * OpenAPI 3.1.0 仕様を JSON で配信するエンドポイント。
+ * `/api/openapi.json` でアクセス可能。
+ */
+import { openApiSpec } from '~/modules/openapi-spec';
+
+export async function loader() {
+  return new Response(JSON.stringify(openApiSpec), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'public, max-age=300, s-maxage=3600',
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    },
+  });
+}


### PR DESCRIPTION
## Summary

- 公開API仕様を独立ページ `/api-docs` に分離し、OpenAPI 3.1.0 準拠の詳細ドキュメントに書き直した
- 機械可読版 `/api/openapi.json` も同時に提供し、コード生成ツールやAIエージェントから直接利用可能に
- READMEとFAQから個別API説明を除去し、`/api-docs` への参照のみに簡素化（情報の二重管理を回避）

## 変更内容

### 新規追加
- `app/modules/openapi-spec.ts` — OpenAPI 3.1.0 仕様（単一情報源）
- `app/routes/api.openapi[.]json.tsx` — `/api/openapi.json` で仕様をJSON配信
- `app/routes/_layout.api-docs.tsx` — `/api-docs` 人間可読ドキュメント

### 既存変更
- `app/components/Headings.tsx` — H4見出しを追加
- `app/routes/_layout.readme.tsx` — 旧APIセクション（150行超）を削除し、`/api-docs` への簡潔な参照と化

## ドキュメントの内容

- 概要（バージョン・ベースURL・認証・CORS・キャッシュ・ライセンス）
- レート制限・共通エラー
- エンドポイント別の詳細
  - HTTPメソッド・パス
  - パラメータ表（位置・型・必須・制約・デフォルト・説明）
  - レスポンススキーマ表（フィールド・型・nullable・説明）
  - ステータスコード別（200 / 400 / 404）
  - リクエスト/レスポンス例
- 再利用スキーマ定義（SearchMetadata, TagCount, SearchHit, Post, Tag, Comment, PostSummary, Error）
- 利用条件と問い合わせ先

## Test plan

- [ ] Preview環境で `/api-docs` が表示されること
- [ ] `/api/openapi.json` が 200 + 正しいJSONを返すこと（`openapi: "3.1.0"`, 2 paths, 9 schemas）
- [ ] `/readme` のFAQに `/api-docs` へのリンクがあること
- [ ] 既存の `/api/search` `/api/posts/:postId` は影響を受けないこと（loaderロジック未変更）

🤖 Generated with [Claude Code](https://claude.com/claude-code)