### PR TITLE
chore: API仕様からライセンスに関する記述を削除した

### DIFF
--- a/app/modules/openapi-spec.ts
+++ b/app/modules/openapi-spec.ts
@@ -16,10 +16,6 @@ export const openApiSpec = {
       name: '管理人',
       url: 'https://x.com/messages/compose?recipient_id=1249916069344473088',
     },
-    license: {
-      name: 'CC BY-SA 4.0',
-      url: 'https://creativecommons.org/licenses/by-sa/4.0/',
-    },
   },
   servers: [
     {

--- a/app/routes/_layout.api-docs.tsx
+++ b/app/routes/_layout.api-docs.tsx
@@ -177,12 +177,6 @@ export default function Component() {
         <li>
           <strong>キャッシュ:</strong> <code>Cache-Control: public, max-age=60, s-maxage=300</code>
         </li>
-        <li>
-          <strong>ライセンス:</strong> 投稿データは
-          <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a>
-          （Wikipediaと同じライセンス）。利用時は <code>healthy-person-emulator.org</code>{' '}
-          を出典として明示してください。
-        </li>
       </ul>
 
       <H3>レート制限</H3>


### PR DESCRIPTION
## Summary

API仕様ページの概要セクションとOpenAPIスペックの `info.license` からライセンス記述を削除する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)