### PR TITLE
feat: サイドメニューにAPI仕様ページへのリンクを追加した

### DIFF
--- a/app/utils/itemMenu.ts
+++ b/app/utils/itemMenu.ts
@@ -10,6 +10,7 @@ import {
   LogIn,
   FilePlus,
   Bookmark,
+  Code2,
 } from 'lucide-react';
 
 export function getNavItems(isSignedIn: boolean) {
@@ -19,6 +20,7 @@ export function getNavItems(isSignedIn: boolean) {
     { to: '/?tab=random', text: 'ランダム', icon: Shuffle },
     { to: '/support', text: 'サポートする', icon: HandCoins },
     { to: '/readme', text: 'サイト説明', icon: BookText },
+    { to: '/api-docs', text: 'API仕様', icon: Code2 },
     {
       to: '/feed?p=1&type=unboundedLikes',
       text: '無期限いいね順',


### PR DESCRIPTION
# 概要

- 直前のPRで `/api-docs` ページを独立させたが、サイト内に導線がなくユーザーが辿り着けない状態だった
- このままだとAPI仕様ページが事実上アクセス不能で、外部からの直リンクでしか参照できない
- サイドメニュー（デスクトップ／モバイル共通の `getNavItems`）に「API仕様」項目を追加した

# 変更内容

## サイドメニューにAPI仕様ページへのリンクを追加

`app/utils/itemMenu.ts` の `getNavItems` に1項目追加した。デスクトップのサイドバー・モバイルのドロワーメニュー双方で表示される。

| 項目 | 値 |
|---|---|
| パス | `/api-docs` |
| ラベル | API仕様 |
| アイコン | `Code2` (lucide-react) |
| 位置 | 「サイト説明」の直後 |

# 確認したこと

- [x] `app/utils/itemMenu.ts` の差分が意図通りであること

# 補足

- アイコンはAPI仕様ページにふさわしいものとして `Code2` を選択した。変更したい場合は気軽に指摘してほしい

🤖 Generated with [Claude Code](https://claude.com/claude-code)