### PR TITLE
歓迎判定モデルをMistral Small 3.1へ切り替えた

### DIFF
--- a/app/modules/security.server.ts
+++ b/app/modules/security.server.ts
@@ -1,4 +1,22 @@
+import { z } from 'zod';
+
 const CF_TURNSTILE_VERIFY_ENDPOINT = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
+const WELCOMED_EXPLANATION = 'ガイドラインに準拠した投稿です';
+const GUIDELINE_EXPLANATIONS = [
+  '自身の経験に基づかない知識が記述されています',
+  'テスト投稿です',
+  'スパム投稿です',
+  '基本的人権を侵害する行為が奨励されています',
+  '違法な行為を奨励する内容を含みます',
+  WELCOMED_EXPLANATION,
+] as const;
+const GUIDELINE_CHECK_SCHEMA = z
+  .object({
+    isWelcomed: z.boolean(),
+    explanation: z.enum(GUIDELINE_EXPLANATIONS),
+  })
+  .strict()
+  .refine(({ isWelcomed, explanation }) => isWelcomed === (explanation === WELCOMED_EXPLANATION));
 
 let _cfTurnstileSecretKey: string | undefined;
 let _cfTurnstileSiteKey: string | undefined;
@@ -76,7 +94,7 @@ export async function getJudgeWelcomedByGenerativeAI(postContent: string, postTi
 
   if (!_aiBinding) {
     console.warn('[security] AI binding not available, skipping guideline check');
-    return { isWelcomed: true, explanation: 'テスト投稿です' };
+    return { isWelcomed: true, explanation: WELCOMED_EXPLANATION };
   }
 
   const systemPrompt = `あなたはHTMLで表現されたテキストを分析して、そのテキストが「歓迎されない投稿」に該当するかどうかを判断するAIです。
@@ -95,57 +113,31 @@ export async function getJudgeWelcomedByGenerativeAI(postContent: string, postTi
 - 違法・もしくは基本的人権を侵害するような表現が含まれていた場合でも、奨励しているわけではない場合は「歓迎される投稿」と判断してください。
 - 違法・もしくは基本的人権を侵害するような表現が含まれていた場合でも、反省している場合は「歓迎される投稿」と判断してください。
 
-JSONで結果を返してください。`;
+JSONで結果を返してください。
 
-  const result = await _aiBinding.run('@cf/meta/llama-3.3-70b-instruct-fp8-fast', {
-    messages: [
-      { role: 'system', content: systemPrompt },
-      { role: 'user', content: `${postTitle}\n${postContent}` },
-    ],
-    response_format: {
-      type: 'json_schema' as const,
-      json_schema: {
-        name: 'guideline_check',
-        schema: {
-          type: 'object',
-          properties: {
-            isWelcomed: { type: 'boolean' },
-            explanation: {
-              type: 'string',
-              enum: [
-                'テスト投稿です',
-                'スパム投稿です',
-                '基本的人権を侵害する行為が奨励されています',
-                '違法な行為を奨励する内容を含みます',
-                'ガイドラインに準拠した投稿です',
-              ],
-            },
-          },
-          required: ['isWelcomed', 'explanation'],
-        },
-        strict: true,
-      },
-    },
-  });
-
-  const raw = (result as { response?: unknown }).response;
-  if (!raw) {
-    console.warn('[security] AI returned empty response, defaulting to welcomed');
-    return { isWelcomed: true, explanation: 'ガイドラインに準拠した投稿です' };
-  }
+出力は必ず {"isWelcomed": boolean, "explanation": string} の2キーだけを持つJSONオブジェクトにし、Markdownのコードフェンスは使わないでください。
+explanationは${GUIDELINE_EXPLANATIONS.map((explanation) => `「${explanation}」`).join('、')}のいずれかだけを使用してください。
+isWelcomedがtrueの場合は「${WELCOMED_EXPLANATION}」、falseの場合はそれ以外の理由を使用してください。`;
 
   try {
-    // json_schema使用時、responseはオブジェクトまたはJSON文字列で返る
-    const parsed = (typeof raw === 'object' ? raw : JSON.parse(raw as string)) as {
-      isWelcomed: boolean;
-      explanation: string;
-    };
-    return {
-      isWelcomed: parsed.isWelcomed,
-      explanation: parsed.explanation,
-    };
-  } catch {
-    console.warn('[security] Failed to parse AI response, defaulting to welcomed:', raw);
-    return { isWelcomed: true, explanation: 'ガイドラインに準拠した投稿です' };
+    const result = await _aiBinding.run('@cf/mistralai/mistral-small-3.1-24b-instruct', {
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: `${postTitle}\n${postContent}` },
+      ],
+      guided_json: z.toJSONSchema(GUIDELINE_CHECK_SCHEMA),
+      temperature: 0,
+      max_tokens: 128,
+    });
+    return GUIDELINE_CHECK_SCHEMA.parse(JSON.parse(result.response));
+  } catch (error) {
+    const errorKind =
+      error instanceof SyntaxError
+        ? 'invalid_json'
+        : error instanceof z.ZodError
+          ? 'invalid_schema'
+          : 'ai_error';
+    console.warn(`[security] AI guideline check failed (${errorKind}), defaulting to welcomed`);
+    return { isWelcomed: true, explanation: WELCOMED_EXPLANATION };
   }
 }

--- a/app/modules/security.test.ts
+++ b/app/modules/security.test.ts
@@ -1,18 +1,65 @@
 import { getJudgeWelcomedByGenerativeAI, initSecurity } from './security.server';
-import { describe, it, expect, beforeAll } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+const WELCOMED_RESULT = {
+  isWelcomed: true,
+  explanation: 'ガイドラインに準拠した投稿です',
+};
+
+function initWithAI(response?: unknown) {
+  const run =
+    response instanceof Error
+      ? vi.fn().mockRejectedValue(response)
+      : vi.fn().mockResolvedValue({
+          response: typeof response === 'string' ? response : JSON.stringify(response),
+        });
+  initSecurity({
+    CF_TURNSTILE_SECRET_KEY: 'test',
+    CF_TURNSTILE_SITEKEY: 'test',
+    AI: (response === undefined ? undefined : { run }) as unknown as Ai,
+  });
+  return run;
+}
 
 describe('security.server', () => {
-  beforeAll(() => {
-    initSecurity({
-      CF_TURNSTILE_SECRET_KEY: 'test',
-      CF_TURNSTILE_SITEKEY: 'test',
-      AI: undefined as unknown as Ai,
-    });
+  beforeAll(() => vi.spyOn(console, 'warn').mockImplementation(() => {}));
+  afterAll(() => vi.restoreAllMocks());
+
+  it('Mistralの構造化出力で非歓迎判定する', async () => {
+    const result = {
+      isWelcomed: false,
+      explanation: '自身の経験に基づかない知識が記述されています',
+    };
+    const run = initWithAI(result);
+
+    await expect(getJudgeWelcomedByGenerativeAI(testPostHtml, '知識投稿')).resolves.toEqual(result);
+    expect(run).toHaveBeenCalledWith(
+      '@cf/mistralai/mistral-small-3.1-24b-instruct',
+      expect.objectContaining({
+        temperature: 0,
+        max_tokens: 128,
+        guided_json: expect.objectContaining({ additionalProperties: false }),
+      }),
+    );
+    const input = JSON.stringify(run.mock.calls[0]?.[1]);
+    expect(input).toContain(result.explanation);
+    expect(input).toContain('isWelcomedがtrueの場合');
   });
 
-  it('デモキーであればテスト投稿と判断される', async () => {
-    const result = await getJudgeWelcomedByGenerativeAI(testPostHtml, 'プログラムテスト投稿');
-    expect(result.isWelcomed).toBe(true);
+  it.each([
+    ['AI bindingなし', undefined],
+    ['JSONではない', 'not json'],
+    ['boolean型が不正', { ...WELCOMED_RESULT, isWelcomed: 'true' }],
+    ['未知の理由', { isWelcomed: false, explanation: '未知の理由' }],
+    ['trueと理由が矛盾', { isWelcomed: true, explanation: 'テスト投稿です' }],
+    ['falseと理由が矛盾', { isWelcomed: false, explanation: WELCOMED_RESULT.explanation }],
+    ['余分なキー付き', { ...WELCOMED_RESULT, extra: true }],
+    ['AI呼び出し失敗', new Error('AI unavailable')],
+  ])('%sの応答は歓迎として扱う', async (_name, response) => {
+    initWithAI(response);
+    await expect(getJudgeWelcomedByGenerativeAI(testPostHtml, '投稿')).resolves.toEqual(
+      WELCOMED_RESULT,
+    );
   });
 });
 


### PR DESCRIPTION
# 概要

- 投稿の歓迎判定で、現行Llamaは日本語の否定・反省表現を誤って非歓迎にするケースがありました。
- 未見実記事と既知回帰ケースで比較したところ、Mistral Small 3.1は判定精度と応答速度を改善しました。
- 歓迎判定モデルをMistral Small 3.1へ切り替え、構造化出力を実行時にも検証して不正時は歓迎側へ倒します。

# 変更内容

- Workers AIモデルを `@cf/mistralai/mistral-small-3.1-24b-instruct` へ変更
- `guided_json`、`temperature: 0`、`max_tokens: 128` を設定
- 既存ルールに対応する「自身の経験に基づかない知識」の判定理由を追加
- 真偽値・理由enum・余分なキー・真偽と理由の整合性をZodで検証
- AI呼び出し・JSON・schemaの失敗時は歓迎として扱い、安全なエラー種別だけを記録
- OpenAPI、DB、Cloudflare設定、生成型は変更しない

# 確認したこと

- [x] `pnpm exec vp test run`（13 files / 71 tests）
- [x] `pnpm build`
- [x] 対象2ファイルのlint・format・diff check
- [x] Workers AI実測（未見実記事 58/59、既知回帰 26/27）
- [x] Workers AI実測（p50 0.905秒、p95 2.253秒、timeout 0）
- [x] 推定費用 約$0.380 / 1,000件

# 参考

- [Mistral Small 3.1 24B Instruct - Cloudflare Workers AI](https://developers.cloudflare.com/workers-ai/models/mistral-small-3.1-24b-instruct/)
- [Workers AI pricing](https://developers.cloudflare.com/workers-ai/platform/pricing/)

# 補足

- 117件中1件の合成ケースで、booleanと理由が矛盾する生出力が残りました。実装ではこの出力を受理せず、歓迎側へfail-openします。
- 事前に定めた「生出力の契約違反0件」は未達のため、まずDraft PRとして作成します。
- 自傷・未成年の性的内容に関する追加方針は、今回のモデル切り替えには含めていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
