### PR TITLE
X(Twitter)投稿をBuffer API経由に切り替える

### DIFF
--- a/app/modules/admin-delete.server.ts
+++ b/app/modules/admin-delete.server.ts
@@ -28,6 +28,21 @@ export async function deletePost(
     throw new Error(`記事 ID ${postId} が見つかりません`);
   }
 
+  // 2.0 social_post_jobs から投稿IDを取得する
+  // 下のバッチで social_post_jobs を削除してしまうため、先に Buffer Post ID を確保しておく
+  // （Buffer 経由の X 投稿は provider_post_id に Buffer Post ID が入る）
+  const jobRows = await db
+    .select({
+      platform: socialPostJobs.platform,
+      providerPostId: socialPostJobs.providerPostId,
+    })
+    .from(socialPostJobs)
+    .where(eq(socialPostJobs.postId, postId));
+  const jobProviderIds: Record<string, string | undefined> = {};
+  for (const r of jobRows) {
+    jobProviderIds[r.platform] = r.providerPostId ?? undefined;
+  }
+
   // 2. トランザクション内でDB操作
   await db.batch([
     // dim_deleted_posts に記録を挿入
@@ -65,8 +80,10 @@ export async function deletePost(
 
   // 5. SNS投稿削除
   const snsEntries: Array<{ platform: Platform; providerPostId: string }> = [];
-  if (post.tweetIdOfFirstTweet) {
-    snsEntries.push({ platform: 'twitter', providerPostId: post.tweetIdOfFirstTweet });
+  // twitter: Buffer Post ID があれば優先（Buffer 経由削除）。従来の X ID（実ツイートID）は従来APIで削除
+  const twitterDeleteId = jobProviderIds['twitter'] ?? post.tweetIdOfFirstTweet;
+  if (twitterDeleteId) {
+    snsEntries.push({ platform: 'twitter', providerPostId: twitterDeleteId });
   }
   if (post.blueskyPostUriOfFirstPost) {
     snsEntries.push({ platform: 'bluesky', providerPostId: post.blueskyPostUriOfFirstPost });

--- a/app/modules/automation.server.ts
+++ b/app/modules/automation.server.ts
@@ -10,6 +10,7 @@ import { nowUTC } from '../drizzle/utils';
 import type { CloudflareEnv } from '../types/env';
 
 import { postToSocial } from './social/post.server';
+import { waitForBufferPostSent } from './social/buffer.server';
 import { PLATFORMS } from './social/types';
 import type { Platform } from './social/types';
 import { PROGRAM_TEST_PATTERN, ensureResvgWasm, generateOgpPng, parseTable } from './ogp.server';
@@ -270,9 +271,36 @@ export async function handleSocialPostConsumer(
       })
       .where(eq(socialPostJobs.id, payload.job_id));
 
-    // Also update dim_posts with the provider post ID
+    // dim_posts の共有フラグ/投稿ID更新
+    // Buffer 経由 (X) は providerPostId が Buffer Post ID のため、
+    // dim_posts.tweet_id_of_first_tweet(実XツイートID) には書き込まない。
+    // 共有済みフラグのみ立て、実X ID は下の Buffer 送信完了待ちで回収する。
     if (providerPostId) {
-      await updateDimPostsSocialId(db, payload.post_id, payload.platform, providerPostId);
+      await updateDimPostsSocialId(
+        db,
+        payload.post_id,
+        payload.platform,
+        providerPostId,
+        result.viaBuffer === true,
+      );
+    }
+
+    // Buffer 経由 (X) のみ: Buffer 投稿が sent になるまで待ち、実XツイートIDを回収して
+    // 公開リンク (SNSLinks) 用の dim_posts.tweet_id_of_first_tweet を更新する。
+    if (result.viaBuffer === true && providerPostId) {
+      const bufferApiKey = ((await env.SS_BUFFER_API_KEY?.get()) ?? '').trim();
+      if (bufferApiKey) {
+        const xStatusId = await waitForBufferPostSent(bufferApiKey, providerPostId);
+        if (xStatusId) {
+          await db.run(
+            sql`UPDATE dim_posts SET tweet_id_of_first_tweet = ${xStatusId} WHERE post_id = ${payload.post_id} AND tweet_id_of_first_tweet IS NULL`,
+          );
+        } else {
+          console.log(
+            `[automation] Buffer 投稿 ${providerPostId} の実XツイートID回収に失敗（公開リンクは付与されません）`,
+          );
+        }
+      }
     }
 
     console.log(
@@ -399,12 +427,21 @@ async function updateDimPostsSocialId(
   postId: number,
   platform: Platform,
   providerPostId: string,
+  viaBuffer = false,
 ): Promise<void> {
   const columnMap: Record<Platform, string> = {
     twitter: 'tweet_id_of_first_tweet',
     bluesky: 'bluesky_post_uri_of_first_post',
     activitypub: 'misskey_note_id_of_first_note',
   };
+
+  if (viaBuffer) {
+    // Buffer 経由: 実XツイートIDは未確定なので、共有済みフラグのみ立てる
+    await db.run(
+      sql`UPDATE dim_posts SET is_sns_shared = 1 WHERE post_id = ${postId} AND is_sns_shared = 0`,
+    );
+    return;
+  }
 
   // Only update if not already set (first post only)
   await db.run(

--- a/app/modules/social/buffer.server.ts
+++ b/app/modules/social/buffer.server.ts
@@ -1,0 +1,239 @@
+/**
+ * Buffer API client for X (Twitter) posting via Buffer.
+ *
+ * 対象: X (Twitter) のみ。Buffer 経由で投稿・削除を行う。
+ *
+ * API仕様 (developers.buffer.com):
+ *  - エンドポイント: POST https://api.buffer.com (GraphQL 単一エンドポイント)
+ *  - 認証: Authorization: Bearer <APIキー>
+ *
+ * セキュリティ注意:
+ *  - 本番APIキーは Cloudflare Secrets Store (SS_BUFFER_API_KEY) から取得する。
+ *  - 絶対にログ出力・ハードコードしないこと。エラー文言にも含めない。
+ */
+
+const BUFFER_ENDPOINT = 'https://api.buffer.com';
+
+interface GqlEnvelope {
+  data?: unknown;
+  errors?: Array<{ message: string }>;
+}
+
+async function gql<T>(
+  apiKey: string,
+  query: string,
+  variables?: Record<string, unknown>,
+): Promise<T> {
+  const res = await fetch(BUFFER_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  const bodyText = await res.text();
+  if (!res.ok) {
+    throw new Error(`Buffer request failed (${res.status})`);
+  }
+
+  const json = JSON.parse(bodyText) as GqlEnvelope;
+  if (json.errors && json.errors.length > 0) {
+    throw new Error(`Buffer API error: ${json.errors.map((e) => e.message).join('; ')}`);
+  }
+  if (!json.data) {
+    throw new Error('Buffer API returned no data');
+  }
+  return json.data as T;
+}
+
+interface ChannelInfo {
+  id: string;
+  name: string;
+  service: string;
+}
+
+/**
+ * Buffer アカウント配下の X (Twitter) チャンネルIDを解決する。
+ * 対象は X のみのため、初回に org → channel を引き、X チャンネルを返す。
+ */
+export async function resolveXChannelId(apiKey: string): Promise<string> {
+  const orgData = await gql<{ account: { organizations: { id: string }[] } }>(
+    apiKey,
+    `query GetOrg { account { organizations { id } } }`,
+  );
+  const orgId = orgData?.account?.organizations?.[0]?.id;
+  if (!orgId) throw new Error('Buffer: organization not found');
+
+  // organizationId は OrganizationId スカラー型が要求されるため、変数ではなくインライン化する
+  const chData = await gql<{ channels: ChannelInfo[] }>(
+    apiKey,
+    `query GetChannels {
+      channels(input: { organizationId: "${orgId}" }) { id name service }
+    }`,
+  );
+
+  const x = chData.channels?.find(
+    (c) => c.service.toLowerCase() === 'twitter' || c.service.toLowerCase() === 'x',
+  );
+  if (!x) throw new Error('Buffer: X (Twitter) channel not found');
+  return x.id;
+}
+
+export interface BufferPostParams {
+  text: string;
+  imageUrl?: string;
+  /** 投稿実行時刻 (ISO8601 UTC)。省略時は即時 (customScheduled + now)。 */
+  dueAt?: string;
+}
+
+export interface BufferPostResult {
+  bufferPostId: string;
+}
+
+/**
+ * Buffer 経由で X に即時投稿する。画像は公開URL (R2) を渡す。
+ * 成功時は Buffer の Post ID を返す（X のツイートIDではない）。
+ */
+export async function postToXViaBuffer(
+  apiKey: string,
+  params: BufferPostParams,
+): Promise<BufferPostResult> {
+  const channelId = await resolveXChannelId(apiKey);
+
+  const assets = params.imageUrl
+    ? [{ image: { url: params.imageUrl } }]
+    : [];
+
+  // dueAt 指定があれば customScheduled、なければ即時投稿 shareNow
+  // （dueAt=現在時刻は「未来でなければならない」ため即時投稿は shareNow を使う）
+  const mode = params.dueAt ? 'customScheduled' : 'shareNow';
+  const input: Record<string, unknown> = {
+    text: params.text,
+    channelId,
+    schedulingType: 'automatic',
+    mode,
+    assets,
+  };
+  if (params.dueAt) {
+    input.dueAt = params.dueAt;
+  }
+
+  const data = await gql<{
+    createPost: { post?: { id?: string } | null; message?: string };
+  }>(
+    apiKey,
+    `mutation CreatePost($input: CreatePostInput!) {
+      createPost(input: $input) {
+        ... on PostActionSuccess { post { id } }
+        ... on MutationError { message }
+      }
+    }`,
+    { input },
+  );
+
+  const createPost = data.createPost;
+  if (createPost.message) {
+    throw new Error(`Buffer createPost error: ${createPost.message}`);
+  }
+  const bufferPostId = createPost.post?.id;
+  if (!bufferPostId) {
+    throw new Error('Buffer createPost succeeded but returned no post id');
+  }
+  return { bufferPostId };
+}
+
+/**
+ * Buffer の Post ID で投稿を削除する（X API は使わない）。
+ */
+export async function deleteBufferPost(
+  apiKey: string,
+  bufferPostId: string,
+): Promise<void> {
+  const data = await gql<{
+    deletePost: { id?: string; message?: string };
+  }>(
+    apiKey,
+    `mutation DeletePost($input: DeletePostInput!) {
+      deletePost(input: $input) {
+        ... on DeletePostSuccess { id }
+        ... on VoidMutationError { message }
+      }
+    }`,
+    { input: { id: bufferPostId } },
+  );
+
+  if (data.deletePost.message) {
+    throw new Error(`Buffer deletePost error: ${data.deletePost.message}`);
+  }
+}
+
+export interface BufferPostState {
+  status: string;
+  externalLink: string | null;
+}
+
+/**
+ * Buffer の Post ID から、送信状態と公開URL (externalLink) を取得する。
+ * status === 'sent' になると externalLink に実X投稿URLが入る。
+ */
+export async function fetchBufferPostState(
+  apiKey: string,
+  bufferPostId: string,
+): Promise<BufferPostState> {
+  const data = await gql<{
+    post: { status?: string | null; externalLink?: string | null } | null;
+  }>(
+    apiKey,
+    `query GetPost($input: PostInput!) {
+      post(input: $input) { status externalLink }
+    }`,
+    { input: { id: bufferPostId } },
+  );
+
+  const post = data.post;
+  return {
+    status: post?.status ?? 'unknown',
+    externalLink: post?.externalLink ?? null,
+  };
+}
+
+/**
+ * externalLink (例: https://x.com/{handle}/status/{tweetId}) から実XツイートIDを抽出する。
+ * 抽出できない場合は null。
+ */
+export function extractXStatusIdFromUrl(url: string | null | undefined): string | null {
+  if (!url) return null;
+  // URL 末尾の /status/{id} を拾う
+  const m = url.match(/\/status\/([A-Za-z0-9_]+)/i);
+  return m ? m[1] : null;
+}
+
+/**
+ * Buffer 投稿が「実際にXへ公開された (status: sent)」状態になるまで待ち、
+ * externalLink から実XツイートIDを回収する。
+ *
+ * - Queue consumer の wall time 上限(15分)の範囲内であること
+ *   （fetch 待ちはCPU時間に含まれない）
+ * - タイムアウト or status: error で実X IDが得られなかった場合は null を返す
+ *   （best-effort。この場合は公開リンクは付かず、後続の reconcile で補完可能）
+ */
+export async function waitForBufferPostSent(
+  apiKey: string,
+  bufferPostId: string,
+  opts?: { pollIntervalMs?: number; maxWaitMs?: number },
+): Promise<string | null> {
+  const pollIntervalMs = opts?.pollIntervalMs ?? 15_000;
+  const maxWaitMs = opts?.maxWaitMs ?? 5 * 60_000; // 5分
+  const deadline = Date.now() + maxWaitMs;
+
+  while (Date.now() < deadline) {
+    const state = await fetchBufferPostState(apiKey, bufferPostId);
+    if (state.status === 'sent' || state.status === 'error') {
+      return extractXStatusIdFromUrl(state.externalLink);
+    }
+    await new Promise((r) => setTimeout(r, pollIntervalMs));
+  }
+  return null;
+}

--- a/app/modules/social/delete.server.ts
+++ b/app/modules/social/delete.server.ts
@@ -7,6 +7,7 @@ import type { SocialDeleteParams } from './types';
 import { deleteFromTwitter } from './twitter.server';
 import { deleteFromBluesky } from './bluesky.server';
 import { deleteFromMisskey } from './misskey.server';
+import { deleteBufferPost } from './buffer.server';
 
 export async function deleteFromSocial(
   env: CloudflareEnv,
@@ -20,13 +21,7 @@ export async function deleteFromSocial(
 
   switch (params.platform) {
     case 'twitter': {
-      const creds = {
-        consumerKey: await env.SS_TWITTER_CK.get(),
-        consumerSecret: await env.SS_TWITTER_CS.get(),
-        accessToken: await env.SS_TWITTER_AT.get(),
-        accessTokenSecret: await env.SS_TWITTER_ATS.get(),
-      };
-      return deleteFromTwitter(creds, params.providerPostId);
+      return deleteFromX(env, params);
     }
     case 'bluesky': {
       const creds = {
@@ -42,4 +37,27 @@ export async function deleteFromSocial(
     default:
       throw new Error(`Unknown platform: ${params.platform}`);
   }
+}
+
+/**
+ * X (Twitter) 投稿削除。Buffer APIキーが設定されていれば Buffer Post ID で
+ * Buffer 経由削除、なければ従来の X API 直接削除にフォールバックする。
+ * ※ Buffer 経由で投稿した場合、params.providerPostId は Buffer Post ID。
+ */
+async function deleteFromX(env: CloudflareEnv, params: SocialDeleteParams): Promise<void> {
+  // SS_BUFFER_API_KEY binding が未設定環境（テスト・一部環境）でも動くよう optional chaining で安全化
+  const bufferApiKey = ((await env.SS_BUFFER_API_KEY?.get()) ?? '').trim();
+
+  if (bufferApiKey) {
+    await deleteBufferPost(bufferApiKey, params.providerPostId);
+    return;
+  }
+
+  const creds = {
+    consumerKey: await env.SS_TWITTER_CK.get(),
+    consumerSecret: await env.SS_TWITTER_CS.get(),
+    accessToken: await env.SS_TWITTER_AT.get(),
+    accessTokenSecret: await env.SS_TWITTER_ATS.get(),
+  };
+  await deleteFromTwitter(creds, params.providerPostId);
 }

--- a/app/modules/social/post.server.ts
+++ b/app/modules/social/post.server.ts
@@ -5,9 +5,10 @@
 
 import type { CloudflareEnv } from '~/types/env';
 import type { SocialPostParams, SocialPostResult } from './types';
-import { postToTwitter } from './twitter.server';
+import { postToTwitter, createPostText } from './twitter.server';
 import { postToBluesky } from './bluesky.server';
 import { postToMisskey } from './misskey.server';
+import { postToXViaBuffer } from './buffer.server';
 
 export async function postToSocial(
   env: CloudflareEnv,
@@ -21,13 +22,7 @@ export async function postToSocial(
 
   switch (params.platform) {
     case 'twitter': {
-      const creds = {
-        consumerKey: await env.SS_TWITTER_CK.get(),
-        consumerSecret: await env.SS_TWITTER_CS.get(),
-        accessToken: await env.SS_TWITTER_AT.get(),
-        accessTokenSecret: await env.SS_TWITTER_ATS.get(),
-      };
-      return postToTwitter(creds, params);
+      return postToX(env, params);
     }
     case 'bluesky': {
       const creds = {
@@ -43,4 +38,31 @@ export async function postToSocial(
     default:
       throw new Error(`Unknown platform: ${params.platform}`);
   }
+}
+
+/**
+ * X (Twitter) 投稿。Buffer APIキーが設定されていれば Buffer 経由、
+ * なければ従来の X API 直接投稿にフォールバックする。
+ */
+async function postToX(env: CloudflareEnv, params: SocialPostParams): Promise<SocialPostResult> {
+  // SS_BUFFER_API_KEY binding が未設定の環境（テスト・一部環境）でも動くよう optional chaining で安全化
+  const bufferApiKey = ((await env.SS_BUFFER_API_KEY?.get()) ?? '').trim();
+
+  if (bufferApiKey) {
+    const text = createPostText(params.postTitle, params.postUrl, params.messageType);
+    const { bufferPostId } = await postToXViaBuffer(bufferApiKey, {
+      text,
+      imageUrl: params.ogUrl || undefined,
+    });
+    return { providerPostId: bufferPostId, viaBuffer: true };
+  }
+
+  // フォールバック: X API 直接投稿
+  const creds = {
+    consumerKey: await env.SS_TWITTER_CK.get(),
+    consumerSecret: await env.SS_TWITTER_CS.get(),
+    accessToken: await env.SS_TWITTER_AT.get(),
+    accessTokenSecret: await env.SS_TWITTER_ATS.get(),
+  };
+  return postToTwitter(creds, params);
 }

--- a/app/modules/social/report.server.ts
+++ b/app/modules/social/report.server.ts
@@ -5,7 +5,8 @@
 
 import type { CloudflareEnv } from '~/types/env';
 import { queryBigQuery } from '~/modules/bigquery.server';
-import { postToTwitter, tweetRaw } from './twitter.server';
+import { postToTwitter, tweetRaw, createPostText } from './twitter.server';
+import { postToXViaBuffer } from './buffer.server';
 import type { TwitterCredentials } from './types';
 
 function requireBigQueryCredentials(env: CloudflareEnv): string {
@@ -57,17 +58,25 @@ export async function reportLegendary(env: CloudflareEnv): Promise<{ processed: 
     return { processed: articles.length };
   }
 
-  const creds = await getTwitterCreds(env);
+  const bufferApiKey = ((await env.SS_BUFFER_API_KEY?.get()) ?? '').trim();
+  const creds = bufferApiKey ? null : await getTwitterCreds(env);
+
   for (const article of articles) {
     const postId = article.post_id as number;
     const postTitle = article.post_title as string;
     const postUrl = `https://healthy-person-emulator.org/archives/${postId}`;
 
-    await postToTwitter(creds, {
-      postTitle,
-      postUrl,
-      messageType: 'legendary',
-    });
+    if (bufferApiKey) {
+      await postToXViaBuffer(bufferApiKey, {
+        text: createPostText(postTitle, postUrl, 'legendary'),
+      });
+    } else {
+      await postToTwitter(creds!, {
+        postTitle,
+        postUrl,
+        messageType: 'legendary',
+      });
+    }
   }
 
   return { processed: articles.length };
@@ -106,8 +115,13 @@ export async function reportWeekly(env: CloudflareEnv): Promise<{ posted: boolea
     return { posted: false };
   }
 
-  const creds = await getTwitterCreds(env);
-  await tweetRaw(creds, tweetText);
+  const bufferApiKey = ((await env.SS_BUFFER_API_KEY?.get()) ?? '').trim();
+  if (bufferApiKey) {
+    await postToXViaBuffer(bufferApiKey, { text: tweetText });
+  } else {
+    const creds = await getTwitterCreds(env);
+    await tweetRaw(creds, tweetText);
+  }
 
   return { posted: true };
 }

--- a/app/modules/social/types.ts
+++ b/app/modules/social/types.ts
@@ -11,6 +11,8 @@ export interface SocialPostParams {
 
 export interface SocialPostResult {
   providerPostId: string;
+  /** Buffer 経由での投稿 (X) かどうか。true なら providerPostId は Buffer の Post ID。 */
+  viaBuffer?: boolean;
 }
 
 export interface SocialDeleteParams {

--- a/app/types/env.ts
+++ b/app/types/env.ts
@@ -37,6 +37,7 @@ export interface CloudflareEnv {
   SS_BLUESKY_USER: { get(): Promise<string> };
   SS_BLUESKY_PASSWORD: { get(): Promise<string> };
   SS_MISSKEY_TOKEN: { get(): Promise<string> };
+  SS_BUFFER_API_KEY: { get(): Promise<string> };
   SS_AUTOMATION_DRY_RUN: { get(): Promise<string> };
   // GCS export (D1 → GCS Parquet) — SA key JSON stored as Worker Secret
   GCS_CREDENTIALS?: string;

--- a/scripts/test-buffer-post.ts
+++ b/scripts/test-buffer-post.ts
@@ -1,0 +1,80 @@
+/**
+ * Buffer 経由 X 投稿の実テストランナー
+ *
+ * 実Xアカウントに Buffer 経由で実際に投稿するテストです。
+ * 本番APIキーは「環境変数」で渡してください（ログ・ファイル・git に残さない）。
+ *
+ * 使い方:
+ *   BUFFER_API_KEY=<APIキー> npx tsx scripts/test-buffer-post.ts \
+ *     --title "最新記事タイトル" \
+ *     --url "https://healthy-person-emulator.org/archives/<id>" \
+ *     --image-url "https://static.healthy-person-emulator.org/ogp/<id>.png" \
+ *     [--message-type new|legendary|random]   # 既定: new
+ *
+ * 最新記事の取得 (wrangler ログイン後):
+ *   npx wrangler d1 execute healthy-person-emulator-db --remote \
+ *     --command "SELECT post_id, post_title, ogp_image_url FROM dim_posts ORDER BY post_id DESC LIMIT 1"
+ *
+ * 注意: このスクリプトは APIキーを一切ログ出力しません。
+ */
+import { postToXViaBuffer, waitForBufferPostSent } from '../app/modules/social/buffer.server';
+import { createPostText } from '../app/modules/social/twitter.server';
+
+function parseArgs(argv: string[]): Record<string, string> {
+  const args: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith('--')) {
+      args[a.slice(2)] = argv[++i] ?? '';
+    }
+  }
+  return args;
+}
+
+async function main(): Promise<void> {
+  const apiKey = process.env.BUFFER_API_KEY?.trim();
+  if (!apiKey) {
+    console.error('BUFFER_API_KEY 環境変数が設定されていません。');
+    process.exit(1);
+  }
+
+  const args = parseArgs(process.argv.slice(2));
+  const title = args.title ?? '健常者エミュレータ事例集 Buffer接続テスト';
+  const url = args.url ?? 'https://healthy-person-emulator.org/';
+  const messageType = (args['message-type'] ?? 'new') as 'new' | 'legendary' | 'random';
+  const imageUrl = args['image-url'] || undefined;
+
+  const text = createPostText(title, url, messageType);
+
+  console.log('--- 投稿内容 ---');
+  console.log(text);
+  console.log('image:', imageUrl ?? '(なし)');
+  console.log('');
+
+  console.log('--- [1/3] Buffer に投稿 (createPost) ---');
+  const { bufferPostId } = await postToXViaBuffer(apiKey, { text, imageUrl });
+  console.log('Buffer Post ID:', bufferPostId);
+  console.log('');
+
+  console.log('--- [2/3] Buffer がXへ公開 (sent) するまで待機 ---');
+  const xStatusId = await waitForBufferPostSent(apiKey, bufferPostId, {
+    pollIntervalMs: 15_000,
+    maxWaitMs: 5 * 60_000,
+  });
+  console.log('');
+
+  console.log('--- [3/3] 結果 ---');
+  if (xStatusId) {
+    console.log('実XツイートID:', xStatusId);
+    console.log('X投稿URL: https://x.com/x/status/' + xStatusId);
+  } else {
+    console.log(
+      '実XツイートIDの回収に失敗（タイムアウト/エラー）。Buffer ダッシュボード (https://publish.buffer.com) で確認してください。',
+    );
+  }
+}
+
+main().catch((e) => {
+  console.error('FAILED:', e instanceof Error ? e.message : String(e));
+  process.exit(1);
+});

--- a/tests/modules/social/buffer.server.test.ts
+++ b/tests/modules/social/buffer.server.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  postToXViaBuffer,
+  deleteBufferPost,
+  fetchBufferPostState,
+  extractXStatusIdFromUrl,
+  waitForBufferPostSent,
+} from '~/modules/social/buffer.server';
+
+const API_KEY = 'test-api-key';
+
+function mockFetchSequence(responses: Array<{ body: unknown; status?: number }>) {
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  let i = 0;
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ url: String(url), init: init ?? {} });
+      const r = responses[Math.min(i, responses.length - 1)];
+      i++;
+      return new Response(JSON.stringify(r.body), {
+        status: r.status ?? 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }),
+  );
+  return calls;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('postToXViaBuffer', () => {
+  it('Xチャンネル解決 → createPost を投げ、Buffer Post ID を返す', async () => {
+    const calls = mockFetchSequence([
+      { body: { data: { account: { organizations: [{ id: 'org1' }] } } } },
+      { body: { data: { channels: [{ id: 'ch1', name: 'X', service: 'twitter' }] } } },
+      { body: { data: { createPost: { post: { id: 'buf-123' } } } } },
+    ]);
+
+    const res = await postToXViaBuffer(API_KEY, {
+      text: 'テスト投稿',
+      imageUrl: 'https://static.example.com/ogp/1.png',
+    });
+
+    expect(res.bufferPostId).toBe('buf-123');
+    expect(calls.length).toBe(3);
+
+    // 認証ヘッダ (Bearer + APIキー)
+    const headers = calls[2].init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe(`Bearer ${API_KEY}`);
+
+    // createPost の入力形状
+    const body = JSON.parse(calls[2].init.body as string);
+    expect(body.variables.input.channelId).toBe('ch1');
+    expect(body.variables.input.text).toBe('テスト投稿');
+    expect(body.variables.input.schedulingType).toBe('automatic');
+    expect(body.variables.input.mode).toBe('shareNow');
+    expect(body.variables.input.dueAt).toBeUndefined();
+    expect(body.variables.input.assets).toEqual([
+      { image: { url: 'https://static.example.com/ogp/1.png' } },
+    ]);
+  });
+
+  it('画像なしの場合は assets が空配列になる', async () => {
+    const calls = mockFetchSequence([
+      { body: { data: { account: { organizations: [{ id: 'org1' }] } } } },
+      { body: { data: { channels: [{ id: 'ch1', name: 'X', service: 'twitter' }] } } },
+      { body: { data: { createPost: { post: { id: 'buf-2' } } } } },
+    ]);
+    await postToXViaBuffer(API_KEY, { text: 'テキストのみ' });
+    const body = JSON.parse(calls[2].init.body as string);
+    expect(body.variables.input.assets).toEqual([]);
+  });
+
+  it('MutationError が返ると throw する', async () => {
+    mockFetchSequence([
+      { body: { data: { account: { organizations: [{ id: 'org1' }] } } } },
+      { body: { data: { channels: [{ id: 'ch1', name: 'X', service: 'twitter' }] } } },
+      { body: { data: { createPost: { message: 'Channel not found' } } } },
+    ]);
+    await expect(postToXViaBuffer(API_KEY, { text: 'x' })).rejects.toThrow(/Channel not found/);
+  });
+
+  it('Xチャンネルが見つからない場合は throw する', async () => {
+    mockFetchSequence([
+      { body: { data: { account: { organizations: [{ id: 'org1' }] } } } },
+      { body: { data: { channels: [{ id: 'c2', name: 'IG', service: 'instagram' }] } } },
+    ]);
+    await expect(postToXViaBuffer(API_KEY, { text: 'x' })).rejects.toThrow(
+      /X \(Twitter\) channel not found/,
+    );
+  });
+
+  it('HTTP非成功時は本文を含めず throw する（キー漏えい防止）', async () => {
+    const calls = mockFetchSequence([
+      { body: { data: { account: { organizations: [{ id: 'org1' }] } } } },
+      { body: { data: { channels: [{ id: 'ch1', name: 'X', service: 'twitter' }] } } },
+      { body: { data: { createPost: { post: { id: 'buf-3' } } } }, status: 500 },
+    ]);
+    // 最後の1回を HTTP 500 に差し替え
+    await postToXViaBuffer(API_KEY, { text: 'x' }).catch((e) => {
+      expect(String(e)).not.toContain(API_KEY);
+      expect(String(e)).toMatch(/500/);
+    });
+    expect(calls.length).toBe(3);
+  });
+});
+
+describe('deleteBufferPost', () => {
+  it('成功時にエラーを投げない', async () => {
+    const calls = mockFetchSequence([{ body: { data: { deletePost: { id: 'buf-1' } } } }]);
+    await expect(deleteBufferPost(API_KEY, 'buf-1')).resolves.toBeUndefined();
+    const body = JSON.parse(calls[0].init.body as string);
+    expect(body.variables.input.id).toBe('buf-1');
+  });
+
+  it('VoidMutationError が返ると throw する', async () => {
+    mockFetchSequence([{ body: { data: { deletePost: { message: 'not found' } } } }]);
+    await expect(deleteBufferPost(API_KEY, 'buf-1')).rejects.toThrow(/not found/);
+  });
+});
+
+describe('fetchBufferPostState', () => {
+  it('status / externalLink を返す', async () => {
+    const calls = mockFetchSequence([
+      { body: { data: { post: { status: 'sent', externalLink: 'https://x.com/foo/status/999' } } } },
+    ]);
+    const s = await fetchBufferPostState(API_KEY, 'buf-1');
+    expect(s.status).toBe('sent');
+    expect(s.externalLink).toBe('https://x.com/foo/status/999');
+    const body = JSON.parse(calls[0].init.body as string);
+    expect(body.variables.input.id).toBe('buf-1');
+  });
+});
+
+describe('extractXStatusIdFromUrl', () => {
+  it('URL からツイートIDを抽出する', () => {
+    expect(extractXStatusIdFromUrl('https://x.com/foo/status/123456789')).toBe('123456789');
+    expect(extractXStatusIdFromUrl('https://twitter.com/foo/status/987654321')).toBe('987654321');
+    expect(extractXStatusIdFromUrl(null)).toBeNull();
+    expect(extractXStatusIdFromUrl('https://example.com/other')).toBeNull();
+    expect(extractXStatusIdFromUrl('')).toBeNull();
+  });
+});
+
+describe('waitForBufferPostSent', () => {
+  it('scheduled → sent に遷移して実XツイートIDを返す', async () => {
+    mockFetchSequence([
+      { body: { data: { post: { status: 'scheduled', externalLink: null } } } },
+      { body: { data: { post: { status: 'sent', externalLink: 'https://x.com/foo/status/777' } } } },
+    ]);
+    const id = await waitForBufferPostSent(API_KEY, 'buf-1', { pollIntervalMs: 10, maxWaitMs: 2000 });
+    expect(id).toBe('777');
+  });
+
+  it('タイムアウトすると null を返す', async () => {
+    mockFetchSequence([{ body: { data: { post: { status: 'scheduled', externalLink: null } } } }]);
+    const id = await waitForBufferPostSent(API_KEY, 'buf-1', { pollIntervalMs: 10, maxWaitMs: 50 });
+    expect(id).toBeNull();
+  });
+});

--- a/wrangler.dev-remote.toml
+++ b/wrangler.dev-remote.toml
@@ -85,6 +85,12 @@ binding = "SS_AUTOMATION_DRY_RUN"
 store_id = "52f3d1be601046039169fad4f66570d1"
 secret_name = "AUTOMATION_DRY_RUN"
 
+# Buffer API key (値は Cloudflare ダッシュボードの Secrets Store → BUFFER_API_KEY で設定)
+[[secrets_store_secrets]]
+binding = "SS_BUFFER_API_KEY"
+store_id = "52f3d1be601046039169fad4f66570d1"
+secret_name = "BUFFER_API_KEY"
+
 # GCS_CREDENTIALS is set via `wrangler secret put GCS_CREDENTIALS`
 
 # --- Module rules: resvg-wasm と NotoSansJP TTF を Worker バンドルに含める ---

--- a/wrangler.dev.toml
+++ b/wrangler.dev.toml
@@ -83,6 +83,12 @@ binding = "SS_AUTOMATION_DRY_RUN"
 store_id = "52f3d1be601046039169fad4f66570d1"
 secret_name = "AUTOMATION_DRY_RUN"
 
+# Buffer API key (値は Cloudflare ダッシュボードの Secrets Store → BUFFER_API_KEY で設定)
+[[secrets_store_secrets]]
+binding = "SS_BUFFER_API_KEY"
+store_id = "52f3d1be601046039169fad4f66570d1"
+secret_name = "BUFFER_API_KEY"
+
 # GCS_CREDENTIALS is set via `wrangler secret put GCS_CREDENTIALS`
 
 # --- Module rules: resvg-wasm と NotoSansJP TTF を Worker バンドルに含める ---

--- a/wrangler.preview.toml
+++ b/wrangler.preview.toml
@@ -82,6 +82,12 @@ binding = "SS_AUTOMATION_DRY_RUN"
 store_id = "52f3d1be601046039169fad4f66570d1"
 secret_name = "AUTOMATION_DRY_RUN"
 
+# Buffer API key (値は Cloudflare ダッシュボードの Secrets Store → BUFFER_API_KEY で設定)
+[[secrets_store_secrets]]
+binding = "SS_BUFFER_API_KEY"
+store_id = "52f3d1be601046039169fad4f66570d1"
+secret_name = "BUFFER_API_KEY"
+
 # GCS_CREDENTIALS is set via `wrangler secret put GCS_CREDENTIALS`
 
 # --- Module rules: resvg-wasm と NotoSansJP TTF を Worker バンドルに含める ---

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -82,6 +82,12 @@ binding = "SS_AUTOMATION_DRY_RUN"
 store_id = "52f3d1be601046039169fad4f66570d1"
 secret_name = "AUTOMATION_DRY_RUN"
 
+# Buffer API key (値は Cloudflare ダッシュボードの Secrets Store → BUFFER_API_KEY で設定)
+[[secrets_store_secrets]]
+binding = "SS_BUFFER_API_KEY"
+store_id = "52f3d1be601046039169fad4f66570d1"
+secret_name = "BUFFER_API_KEY"
+
 # GCS_CREDENTIALS is set via `wrangler secret put GCS_CREDENTIALS`
 
 # --- Migrations: AutomationContainer は v3 で削除済み（OGP生成は Worker 内 SVG 生成に移行） ---


### PR DESCRIPTION
## 概要

X(Twitter)への投稿・削除を **Buffer GraphQL API** 経由に切り替える。これにより従来の **X API直接投稿（`upload.twitter.com` の v1 media や `api.x.com/2/tweets`）のレート制限で投稿できなくなる問題**を回避する。

## 変更内容

### 新規: `app/modules/social/buffer.server.ts`
- `postToXViaBuffer` … `createPost`（`mode: shareNow` で即時投稿）。画像はR2公開URLを `assets` に渡す（**v1 media/upload を撤去**）
- `deleteBufferPost` … `deletePost` を **Buffer Post ID** で実施（X API非依存）
- `waitForBufferPostSent` … `status: sent` までポーリングし、`externalLink` から**実XツイートID**を回収
- `resolveXChannelId` … org → channel 解決でXチャンネルを特定

### 統合（Bufferキー設定時のみ有効・未設定はX API直接にフォールバック）
- `post.server.ts` / `delete.server.ts` / `report.server.ts`（殿堂入り・週次） / `automation.server.ts` / `admin-delete.server.ts`
- `dim_posts.tweet_id_of_first_tweet`（公開リンク用）には実X IDのみを保存し、Buffer IDは書き込まない
- Admin削除は `social_post_jobs` 削除前に Buffer Post ID を取得して Buffer 経由削除

### 設定
- Secrets Store binding `SS_BUFFER_API_KEY`（→ ストア `BUFFER_API_KEY`）をwrangler設定4種と `env.ts` に追加

## 検証
- **実投稿テスト**: 最新記事 post 48942 をBuffer経由で実X投稿成功
  - Buffer Post ID: `6a8455f03dd2d5920efe9e4f`
  - 実XツイートID: `2089697360553082915` → https://x.com/x/status/2089697360553082915
- モックテスト11件追加（`tests/modules/social/buffer.server.test.ts`）、全28テストパス
- 型チェック: 変更ファイルにエラーなし

## 補足
- Buffer APIキーは Cloudflare Secrets Store（書き込み専用）に登録済み
- パフォーマンス: Queue consumer の Wall time 上限（15分）内で `sent` 待ちを実施

## 次のステップ
- プレビューWorkerへのデプロイと、job状態・`dim_posts`更新を含む **end-to-end 動作確認**
- 問題なければ本番デプロイ