### PR TITLE
perf: Buffer XチャンネルIDを設定可能にしてAPI呼び出しを削減

### DIFF
--- a/app/modules/social/buffer.server.ts
+++ b/app/modules/social/buffer.server.ts
@@ -95,12 +95,16 @@ export interface BufferPostResult {
 /**
  * Buffer 経由で X に即時投稿する。画像は公開URL (R2) を渡す。
  * 成功時は Buffer の Post ID を返す（X のツイートIDではない）。
+ *
+ * opts.channelId を渡すとチャンネル解決（Buffer API 2リクエスト）をスキップし、
+ * リクエスト数を削減できる（大量投稿時のレート制限対策）。
  */
 export async function postToXViaBuffer(
   apiKey: string,
   params: BufferPostParams,
+  opts?: { channelId?: string },
 ): Promise<BufferPostResult> {
-  const channelId = await resolveXChannelId(apiKey);
+  const channelId = opts?.channelId?.trim() || (await resolveXChannelId(apiKey));
 
   const assets = params.imageUrl
     ? [{ image: { url: params.imageUrl } }]

--- a/app/modules/social/post.server.ts
+++ b/app/modules/social/post.server.ts
@@ -50,10 +50,15 @@ async function postToX(env: CloudflareEnv, params: SocialPostParams): Promise<So
 
   if (bufferApiKey) {
     const text = createPostText(params.postTitle, params.postUrl, params.messageType);
-    const { bufferPostId } = await postToXViaBuffer(bufferApiKey, {
-      text,
-      imageUrl: params.ogUrl || undefined,
-    });
+    const { bufferPostId } = await postToXViaBuffer(
+      bufferApiKey,
+      {
+        text,
+        imageUrl: params.ogUrl || undefined,
+      },
+      // チャンネルIDが設定済みなら解決をスキップ（Buffer API リクエスト削減）
+      { channelId: env.BUFFER_CHANNEL_ID_X?.trim() || undefined },
+    );
     return { providerPostId: bufferPostId, viaBuffer: true };
   }
 

--- a/app/modules/social/report.server.ts
+++ b/app/modules/social/report.server.ts
@@ -67,9 +67,11 @@ export async function reportLegendary(env: CloudflareEnv): Promise<{ processed: 
     const postUrl = `https://healthy-person-emulator.org/archives/${postId}`;
 
     if (bufferApiKey) {
-      await postToXViaBuffer(bufferApiKey, {
-        text: createPostText(postTitle, postUrl, 'legendary'),
-      });
+      await postToXViaBuffer(
+        bufferApiKey,
+        { text: createPostText(postTitle, postUrl, 'legendary') },
+        { channelId: env.BUFFER_CHANNEL_ID_X?.trim() || undefined },
+      );
     } else {
       await postToTwitter(creds!, {
         postTitle,
@@ -117,7 +119,11 @@ export async function reportWeekly(env: CloudflareEnv): Promise<{ posted: boolea
 
   const bufferApiKey = ((await env.SS_BUFFER_API_KEY?.get()) ?? '').trim();
   if (bufferApiKey) {
-    await postToXViaBuffer(bufferApiKey, { text: tweetText });
+    await postToXViaBuffer(
+    bufferApiKey,
+    { text: tweetText },
+    { channelId: env.BUFFER_CHANNEL_ID_X?.trim() || undefined },
+  );
   } else {
     const creds = await getTwitterCreds(env);
     await tweetRaw(creds, tweetText);

--- a/app/types/env.ts
+++ b/app/types/env.ts
@@ -13,6 +13,8 @@ export interface CloudflareEnv {
   GOOGLE_CLIENT_SECRET: string;
   CLIENT_URL: string;
   BASE_URL: string;
+  /** Buffer X チャンネルID（設定済みなら毎回の解決をスキップして Buffer API 呼び出しを削減） */
+  BUFFER_CHANNEL_ID_X?: string;
   CF_TURNSTILE_SECRET_KEY: string;
   CF_TURNSTILE_SITEKEY: string;
 

--- a/tests/modules/social/buffer.server.test.ts
+++ b/tests/modules/social/buffer.server.test.ts
@@ -83,6 +83,17 @@ describe('postToXViaBuffer', () => {
     await expect(postToXViaBuffer(API_KEY, { text: 'x' })).rejects.toThrow(/Channel not found/);
   });
 
+  it('channelId 指定時はチャンネル解決をスキップし、createPost のみ呼ぶ', async () => {
+    const calls = mockFetchSequence([
+      { body: { data: { createPost: { post: { id: 'buf-cache-1' } } } } },
+    ]);
+    const res = await postToXViaBuffer(API_KEY, { text: 'x' }, { channelId: 'ch-x' });
+    expect(res.bufferPostId).toBe('buf-cache-1');
+    expect(calls.length).toBe(1); // 解決なし・createPost のみ
+    const body = JSON.parse(calls[0].init.body as string);
+    expect(body.variables.input.channelId).toBe('ch-x');
+  });
+
   it('Xチャンネルが見つからない場合は throw する', async () => {
     mockFetchSequence([
       { body: { data: { account: { organizations: [{ id: 'org1' }] } } } },

--- a/wrangler.dev-remote.toml
+++ b/wrangler.dev-remote.toml
@@ -106,3 +106,4 @@ fallthrough = true
 
 [vars]
 BASE_URL = "https://healthy-person-emulator.org"
+BUFFER_CHANNEL_ID_X = ""

--- a/wrangler.dev.toml
+++ b/wrangler.dev.toml
@@ -104,3 +104,4 @@ fallthrough = true
 
 [vars]
 BASE_URL = "https://healthy-person-emulator.org"
+BUFFER_CHANNEL_ID_X = ""

--- a/wrangler.preview.toml
+++ b/wrangler.preview.toml
@@ -103,4 +103,5 @@ fallthrough = true
 
 [vars]
 BASE_URL = "https://preview.healthy-person-emulator.org"
+BUFFER_CHANNEL_ID_X = ""
 ADMIN_EMAILS = "sora32127@gmail.com"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -112,6 +112,7 @@ fallthrough = true
 
 [vars]
 BASE_URL = "https://healthy-person-emulator.org"
+BUFFER_CHANNEL_ID_X = ""
 ADMIN_EMAILS = "sora32127@gmail.com"
 # Set HEALTHCHECK_URL via `wrangler secret put HEALTHCHECK_URL`
 # e.g. https://hc-ping.com/<uuid>


### PR DESCRIPTION
## 概要

大量投稿（バックフィル）で **Buffer APIのレート制限（429）** に当たる問題への対応。
各投稿で毎回 **チャンネル解決（Buffer API 2リクエスト）** を行っていたため、
100回/15分・250回/日の枠をすぐに使い切っていた。XチャンネルIDを事前指定できるようにして解決をスキップする。

## 変更内容
- `buffer.server.ts`: `postToXViaBuffer(apiKey, params, opts?)` に `opts.channelId` を追加。指定があれば `resolveXChannelId` を呼ばない
- `post.server.ts` / `report.server.ts`: `env.BUFFER_CHANNEL_ID_X` を渡す（未設定時は従来どおり解決）
- `env.ts` + wrangler 4設定の `[vars]` に `BUFFER_CHANNEL_ID_X` を追加（空=従来挙動）
- テスト: channelId指定時は解決なし・createPostのみ呼ばれることを追加

## 効果
- 1投稿あたりのBuffer APIリクエスト: **約3〜5回 → 約1〜2回**
- バックフィル等の大量投稿が100回/15分・250回/日の枠内で安定する

## 注記
Buffer APIキー・チャンネルIDは機密ではない（vars / 別途Secrets Storeで管理）。